### PR TITLE
Allow Perl-style regex filters for tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # testthat 0.9.1.9000
 
+* `test_dir()`, `test_package()`, and `test_check()` have an added `...` argument
+  that allows filtering of test files using, e.g., Perl-style regular expressions,
+  or `fixed` character filtering. Arguments in `...` are passed to `grepl()` (@leeper).
+
 * `test_check()` uses a new reporter specifically designed for `R CMD check`.
   It displays a summary at the end of the tests, designed to be <13 lines long
   so test failures in `R CMD check` display something more useful. This will

--- a/R/test-files.r
+++ b/R/test-files.r
@@ -23,10 +23,11 @@ test_env <- function() {
 #'   regular expression will be executed.  Matching will take on the file
 #'   name after it has been stripped of \code{"test-"} and \code{".r"}.
 #' @param env environment in which to execute test suite.
+#' @param ... Additional arguments passed to \code{grepl} to control filtering.
 #' @return a data frame of the summary of test results
 #' @export
 test_dir <- function(path, filter = NULL, reporter = "summary",
-                     env = test_env()) {
+                     env = test_env(), ...) {
   current_reporter <- find_reporter(reporter)
   lister <- ListReporter$new()
   reporter <- MultiReporter$new(reporters = list(current_reporter, lister))
@@ -39,7 +40,7 @@ test_dir <- function(path, filter = NULL, reporter = "summary",
     test_names <- gsub("test-?", "", test_names)
     test_names <- gsub("\\.[rR]", "", test_names)
 
-    files <- files[grepl(filter, test_names)]
+    files <- files[grepl(filter, test_names, ...)]
   }
 
   .custom_test_file <- function(fname) {

--- a/R/test-package.r
+++ b/R/test-package.r
@@ -34,7 +34,7 @@ with_top_env <- function(env, code) {
 #' @export
 #' @examples
 #' \dontrun{test_package("testthat")}
-test_package <- function(package, filter = NULL, reporter = "summary") {
+test_package <- function(package, filter = NULL, reporter = "summary", ...) {
   # Ensure that test package returns silently if called recursively - this
   # will occur if test-all.R ends up in the same directory as all the other
   # tests.
@@ -53,7 +53,7 @@ test_package <- function(package, filter = NULL, reporter = "summary") {
 
   env <- test_pkg_env(package)
   with_top_env(env, {
-    df <- test_dir(test_path, reporter = reporter, env = env, filter = filter)
+    df <- test_dir(test_path, reporter = reporter, env = env, filter = filter, ...)
   })
 
   if (reporter$failed) {
@@ -64,7 +64,7 @@ test_package <- function(package, filter = NULL, reporter = "summary") {
 
 #' @export
 #' @rdname test_package
-test_check <- function(package, filter = NULL, reporter = "check") {
+test_check <- function(package, filter = NULL, reporter = "check", ...) {
   require(package, character.only = TRUE)
 
   test_path <- "testthat"
@@ -75,7 +75,7 @@ test_check <- function(package, filter = NULL, reporter = "check") {
   reporter <- find_reporter(reporter)
   env <- test_pkg_env(package)
   with_top_env(env, {
-    df <- test_dir(test_path, reporter = reporter, env = env, filter = filter)
+    df <- test_dir(test_path, reporter = reporter, env = env, filter = filter, ...)
   })
 
   invisible(df)

--- a/man/test_dir.Rd
+++ b/man/test_dir.Rd
@@ -4,7 +4,7 @@
 \alias{test_dir}
 \title{Run all of the tests in a directory.}
 \usage{
-test_dir(path, filter = NULL, reporter = "summary", env = test_env())
+test_dir(path, filter = NULL, reporter = "summary", env = test_env(), ...)
 }
 \arguments{
 \item{path}{path to tests}
@@ -16,6 +16,8 @@ name after it has been stripped of \code{"test-"} and \code{".r"}.}
 \item{reporter}{reporter to use}
 
 \item{env}{environment in which to execute test suite.}
+
+\item{...}{Additional arguments passed to \code{grepl} to control filtering.}
 }
 \value{
 a data frame of the summary of test results

--- a/man/test_package.Rd
+++ b/man/test_package.Rd
@@ -5,7 +5,7 @@
 \alias{test_package}
 \title{Run all tests in an installed package}
 \usage{
-test_package(package, filter = NULL, reporter = "summary")
+test_package(package, filter = NULL, reporter = "summary", ...)
 
 test_check(package, filter = NULL, reporter = "check")
 }
@@ -17,6 +17,8 @@ regular expression will be executed.  Matching will take on the file
 name after it has been stripped of \code{"test-"} and \code{".r"}.}
 
 \item{reporter}{reporter to use}
+
+\item{...}{Additional arguments passed to \code{grepl} to control filtering.}
 }
 \value{
 a data frame of the summary of test results


### PR DESCRIPTION
Perl-style regular expressions are currently not allowed in the `filter` argument to `test_dir`, `test_package`, and `test_check`. This pull request adds a `perl` argument (logical, default `FALSE`) that enables Perl-style regular expressions, which is passed down to `grepl`.