### PR TITLE
Fix evaluate_promise to return actual value

### DIFF
--- a/R/evaluate-promise.r
+++ b/R/evaluate-promise.r
@@ -51,7 +51,7 @@ evaluate_promise <- function(code, print = FALSE) {
   output <- paste0(readLines(temp, warn = FALSE), collapse = "\n")
 
   list(
-    result = result$result,
+    result = result$value,
     output = output,
     warnings = warnings,
     messages = messages


### PR DESCRIPTION
There seems to be a minor issue with the evaluate_promise function such
that the result value is never returned. After debugging it seems that
the problem is caused by the result name for the result object not being
present (always causing to return NULL) and instead the actual value is
is held in the value name for the result object.