### PR TITLE
Add test coverage with coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,15 @@ before_install:
 
 install:
   - ./travis-tool.sh install_deps
+  - ./travis-tool.sh github_package jimhester/covr
 
 script: ./travis-tool.sh run_tests
 
 on_failure:
   - ./travis-tool.sh dump_logs
+
+after_success:
+  - Rscript -e 'library(covr);coveralls()'
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # testthat
 
 [![Travis-CI Build Status](https://travis-ci.org/hadley/testthat.png?branch=master)](https://travis-ci.org/hadley/testthat) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/hadley/testthat?branch=master)](https://ci.appveyor.com/project/hadley/testthat)
+[![Coverage Status](https://img.shields.io/coveralls/hadley/testthat.svg)](https://coveralls.io/r/hadley/testthat?branch=master)
 
 Testing your code is normally painful and boring. `testthat` tries to make testing as fun as possible, so that you get a visceral satisfaction from writing tests. Testing should be fun, not a drag, so you do it all the time. To make that happen, `testthat`:
 


### PR DESCRIPTION
I did not add this to the AppVeyor CI from https://github.com/hadley/testthat/pull/212 because I am not sure if Rtools will have `gcov` on windows.