### PR TITLE
correct function name in equivalence documentation

### DIFF
--- a/R/expectations-equality.R
+++ b/R/expectations-equality.R
@@ -3,7 +3,7 @@
 #' \itemize{
 #' \item \code{expect_identical} tests with \code{\link{identical}}
 #' \item \code{expect_equal} tests with \code{\link{all.equal}}
-#' \item \code{expect_equal} tests with \code{\link{all.equal}} and
+#' \item \code{expect_equivalent} tests with \code{\link{all.equal}} and
 #'   \code{check.attributes = FALSE}
 #' }
 #


### PR DESCRIPTION
I'm a bit confused about the current documentation of the equivalence checks. My best guess is that the second `expect_equal` should be `expect_equivalent` or am I mistaken here?