### PR TITLE
added run.dontrun option to test_eexample.R

### DIFF
--- a/R/test-example.R
+++ b/R/test-example.R
@@ -7,24 +7,25 @@
 #' @param path For \code{test_examples}, path to directory containing Rd files.
 #'   For \code{test_example}, path to a single Rd file. Remember the working
 #'   directory for tests is \code{tests/testthat}.
+#' @param run.dontrun logical indicating that \dontrun should be ignored.
 #' @export
-test_examples <- function(path = "../../man") {
+test_examples <- function(path = "../../man", run.dontrun = FALSE) {
   man <- dir(path, "\\.Rd$", full.names = TRUE)
   lapply(man, test_example)
 }
 
 #' @export
 #' @rdname test_examples
-test_example <- function(path) {
+test_example <- function(path, run.dontrun = FALSE) {
   ex_path <- file.path(tempdir(), paste0(tools::file_path_sans_ext(basename(path)), ".R"))
-  tools::Rd2ex(path, ex_path)
+  tools::Rd2ex(path, ex_path, commentDontrun = run.dontrun)
   if (!file.exists(ex_path)) return()
-
+  
   env <- new.env(parent = globalenv())
-
+  
   ok <- test_code(path, parse(ex_path), env = globalenv())
   if (ok) succeed(path)
-
+  
   invisible()
 }
 


### PR DESCRIPTION
I've added an option to test_example() and test_examples() that allows testing of the portions of examples that are labeled as \dontrun{} in the man files, using the commentDontrun option in Rd2ex().