### PR TITLE
Make failure location syntax consistent with R reporting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat 0.9.1.9000
 
+* Failure locations are now formated as R error locations.
+
 * Deprecated `library_if_available()` has been removed.
 
 * test (`test_dir()`, `test_file()`, `test_package()`, `test_check()`) functions 

--- a/R/reporter-check.R
+++ b/R/reporter-check.R
@@ -96,7 +96,7 @@ failure_header <- function(x) {
   if (is.null(ref)) {
     location <- ""
   } else {
-    location <- paste0(" (@", attr(ref, "srcfile")$filename, "#", ref[1], ")")
+    location <- paste0(" (at ", attr(ref, "srcfile")$filename, "#", ref[1], ")")
   }
 
   paste0(type, location, ": ", x$test, " ")


### PR DESCRIPTION
This makes it possible to highlight and automatically navigate to errors in ESS (and maybe other IDEs).