### PR TITLE
Update README to reflect devtools::use_testthat() 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Now, recommended practice is to put your tests in `tests/testthat`, and ensure `
 
 ```R
 library(testthat)
+library(yourpackage)
+
 test_check("yourpackage")
 ```
 


### PR DESCRIPTION
This change updates the example in the README to match the template file used by dev_tools::use_testthat() as of hadley/devtools@ef088e6.

See https://github.com/hadley/devtools/blob/ef088e6f39be86adddd8b4191568cf2457783a1e/inst/templates/testthat.R for the template file