### PR TITLE
Fix extraneous NAs from compare.character's message.

### DIFF
--- a/R/compare.r
+++ b/R/compare.r
@@ -78,8 +78,9 @@ compare.character <- function(x, y, ..., max_diffs = 5, max_lines = 5,
   }
 
   width <- width - 6 # allocate space for labels
-  n_show <- seq_len(min(length(diff), max_diffs))
-  show <- which(diff)[n_show]
+  diff_index <- which(diff)
+  n_show <- seq_len(min(length(diff_index), max_diffs))
+  show <- diff_index[n_show]
 
   encode <- function(x) encodeString(x, quote = '"')
   show_x <- str_trunc(encode(x[show]), width * max_lines)

--- a/tests/testthat/test-compare.r
+++ b/tests/testthat/test-compare.r
@@ -32,3 +32,10 @@ test_that("computes correct number of mismatches", {
 test_that("comparing character and non-character fails back to all.equal", {
   expect_match(compare("abc", 1)$message, "target is character")
 })
+
+test_that("comparing character vectors doesn't give a bunch of NAs", {
+    x <- letters[1:5]
+    y <- c("a", "b", "x", "d", "e")
+    expect_equal(compare(x,y)$message,
+                 "1 string mismatches:\nx[3]: \"c\"\ny[3]: \"x\"")
+})


### PR DESCRIPTION
- Consider this example:

        x <- y <- letters[1:5]
        y[3] <- "x"
        expect_equal(x,y)

- The output looked like:

        Error: x not equal to y
        1 string mismatches:
        x[3]: "x"
        y[3]: "c"

        x[NA]: NA
        y[NA]: NA

        x[NA]: NA
        y[NA]: NA

        x[NA]: NA
        y[NA]: NA

        x[NA]: NA
        y[NA]: NA

- This fix eliminates those extraneous lines with `NA`.