### PR TITLE
TAP reporter should use SKIP directive for skipped tests

### DIFF
--- a/R/reporter-tap.r
+++ b/R/reporter-tap.r
@@ -51,6 +51,8 @@ TapReporter <- setRefClass("TapReporter", contains = "Reporter",
                 result <- results[[i]];
                 if (result$passed) {
                     cat('ok', i, result$test, '\n')
+                } else if (result$skipped) {
+                    cat('ok', i, '# SKIP', result$test, '\n')
                 } else {
                     cat('not ok', i, result$test, '\n')
                     msg <- gsub('\n', '\n  ', result$failure_msg)


### PR DESCRIPTION
This change produces the following:
```
ok 194 # SKIP watcher works correctly
```
Compare to examples from the [spec](https://testanything.org/tap-specification.html):
```
ok 2 - # SKIP no /sys directory
ok 23 # skip Insufficient flogiston pressure.
1..0 # Skipped: WWW::Mechanize not installed
```