### PR TITLE
Fix watcher issues

### DIFF
--- a/tests/testthat/test-watcher.r
+++ b/tests/testthat/test-watcher.r
@@ -47,7 +47,7 @@ test_that("watcher works correctly", {
   dir.create(test_path)
 
   delayed.bash.cmd <- function(command) {
-    system(paste0("sleep 1;", command), wait=FALSE)
+    system(paste0("bash -c 'sleep 1;", command, "'"), wait=FALSE)
   }
 
   add.code.file <- function(file.name) {

--- a/tests/testthat/test-watcher.r
+++ b/tests/testthat/test-watcher.r
@@ -35,7 +35,7 @@ test_that("compare state works correctly", {
  })
 
 test_that("watcher works correctly", {
-  skip_on_cran() && skip_on_os("windows")
+  skip_on_cran()
 
   loc <- tempfile("watcher", tmpdir = "/tmp")
   dir.create(loc)

--- a/tests/testthat/test-watcher.r
+++ b/tests/testthat/test-watcher.r
@@ -36,6 +36,12 @@ test_that("compare state works correctly", {
 
 test_that("watcher works correctly", {
   skip_on_cran()
+  if (Sys.which("bash") == "") {
+    skip("bash not available")
+  }
+  if (system("bash -c 'which touch'", ignore.stdout = TRUE) != 0L) {
+    skip("touch (or which) not available")
+  }
 
   loc <- tempfile("watcher", tmpdir = "/tmp")
   dir.create(loc)


### PR DESCRIPTION
- use explicit shell call in test
- use `tryCatch` for checking if digest succeeds
    - the previous approach is still subject to race conditions -- not likely, but possible

CC @eddelbuettel: Would you support an argument to `digest()` that makes it return NA instead of throwing an error?