### PR TITLE
Mark test failures as bold red

### DIFF
--- a/R/reporter-summary.r
+++ b/R/reporter-summary.r
@@ -90,7 +90,7 @@ SummaryReporter <- setRefClass("SummaryReporter", contains = "Reporter",
         cat(paste(reports, collapse = "\n\n"), "\n", sep = "")
 
         if (show_praise && runif(1) < 0.25) {
-          cat("\n", colourise(encourage(), "failed"), "\n", sep = "")
+          cat("\n", colourise(encourage(), "error"), "\n", sep = "")
         }
       }
     }


### PR DESCRIPTION
when encouraging in summary reporter

Otherwise:

```
Error in match.arg(as) : 
  'arg' should be one of “passed”, “skipped”, “error”
Calls: <Anonymous> ... test_files -> <Anonymous> -> cat -> colourise -> match.arg
10: stop(gettextf("'arg' should be one of %s", paste(dQuote(choices), 
        collapse = ", ")), domain = NA)
9: match.arg(as)
8: colourise(encourage(), "failed")
7: cat("\n", colourise(encourage(), "failed"), "\n", sep = "")
6: current_reporter$end_reporter()
5: test_files(paths, reporter = reporter, env = env, ...)
4: testthat::test_dir(test_path, filter = filter, env = env, ...)
3: force(code)
2: with_envvar(r_env_vars(), testthat::test_dir(test_path, filter = filter, 
       env = env, ...))
1: devtools::test("RPostgres", filter = "DBItest")
```