### PR TITLE
compare.numeric message fix for named/unnamed objects

### DIFF
--- a/R/compare.r
+++ b/R/compare.r
@@ -149,7 +149,8 @@ compare.numeric <- function(x, y, ..., max_diffs = 10) {
   if (length(x) != length(y)) return(comparison(FALSE, equal))
 
   if (length(x) == 1) {
-    msg <- paste0(format(x, digits = 3), " - ", format(y, digits = 3),
+    msg <- paste0("[Original msg: ", equal, "]\n",
+      format(x, digits = 3), " - ", format(y, digits = 3),
       " == ", format(x - y, digits = 3))
     return(comparison(FALSE, msg))
   }
@@ -169,6 +170,7 @@ compare.numeric <- function(x, y, ..., max_diffs = 10) {
   mu <- mean(abs(x[diff] - y[diff]), na.rm = TRUE)
 
   msg <- paste0(
+    "[Original msg: ", equal, "]\n",
     sum(diff), "/", length(diff), " mismatches ",
     "(average diff: ", format(mu, digits = 3), ").\n",
     "First ", n, ":\n",

--- a/tests/testthat/test-compare.r
+++ b/tests/testthat/test-compare.r
@@ -58,3 +58,35 @@ test_that("comparing character vectors of different length", {
     paste("^", "Lengths ", " differ\\n", " string mismatch", "\\ny", "\\n", "\\ny", "$",
           sep = "[^\\n]*"))
 })
+
+test_that("comparing named / unnamed numerics", {
+  cmp <- compare(c(1, 2), c(a=1, b=2))
+  expect_match(
+    cmp$message,
+    "names for current but not for target"
+  )
+
+  cmp <- compare(c(a=1, b=2), c(1, 2))
+  expect_match(
+    cmp$message,
+    "names for target but not for current"
+  )
+
+  cmp <- compare(c(a=1, 2), c(1, b=2))
+  expect_match(
+    cmp$message,
+    "Names: 2 string mismatches"
+  )
+
+  cmp <- compare(1, c(a=1))
+  expect_match(
+    cmp$message,
+    "names for current but not for target"
+  )
+
+  cmp <- compare(c(1, 2), c(a=1.0001, b=2.0002), tolerance = 1e-2)
+  expect_match(
+    cmp$message,
+    "names for current but not for target"
+  )
+})


### PR DESCRIPTION
When calling `compare.numeric` to compare numerics that were equal except for names, the message from `all.equal` (via `attr.all.equal`) was being dropped. See the test_compare.r additions for examples. The solution I put in compare.r was to just add in the original message so the user can at least see it, but I don't know if this is the best way to handle it.