### PR TITLE
new expectation: code runs without errors

### DIFF
--- a/R/expectations.r
+++ b/R/expectations.r
@@ -219,6 +219,42 @@ normalise_names <- function(x, ignore.order = FALSE, ignore.case = FALSE) {
   x
 }
 
+#' Expectation: does object executes without error?
+#'
+#' You can either check for the presence of names (leaving \code{expected}
+#' blank), specific names (by suppling a vector of names), or absence of
+#' names (with \code{NULL}).
+#'
+#' @inheritParams expect_that
+#' @family expectations
+#' @export
+#' @examples
+#' expect_try(1)
+#'
+#' \dontrun{
+#' expect_try(stop('fail'))
+#' }
+expect_try <- function (object, info = NULL, label = NULL) {
+  if (is.null(label)) {
+    label <- find_expr("object")
+  }
+  expect_that(eval(substitute(object)), isnot_error(), info, label)
+}
+
+isnot_error <- function ()
+{
+  function(expr) {
+    res <- try(force(expr), TRUE)
+    no_error <- !inherits(res, "try-error")
+    if (no_error) {
+      expectation(TRUE, "threw an error", "no error thrown")
+    } else {
+      expectation(FALSE, "threw an error", "no error thrown")
+    }
+  }
+}
+
+
 #' Expectation: is returned value less or greater than specified value?
 #'
 #' This is useful for ensuring returned value is below a ceiling or above

--- a/tests/testthat/test-expectations.r
+++ b/tests/testthat/test-expectations.r
@@ -25,6 +25,18 @@ test_that("failure to throw an error is a failure", {
   expect_that(res$passed, is_false())
 })
 
+
+test_that("absence of errors are caught with isnot_error", {
+  res <- isnot_error()(log(1))
+  expect_that(res$passed, is_true())
+})
+
+test_that("an error is a failure", {
+  res <- isnot_error()(stop())
+  expect_that(res$passed, is_false())
+})
+
+
 test_that("warnings are caught by gives_warning", {
   f <- function() {
     warning("a")
@@ -119,6 +131,11 @@ test_that("expect_null checks for NULLs", {
 
 test_that("takes_less_than verifies duration", {
   expect_that(1, takes_less_than(1))
+})
+
+test_that("expect_try verifies absence of errors in code", {
+  expect_try(log(1))
+  expect_error(expect_try(stop()), 'threw an error')
 })
 
 test_that("expect_silent checks for out", {


### PR DESCRIPTION
I often use the following structure for testing that something **does not**
throw errors:

```R
res <- try(expr, silent = TRUE)
expect_false(inherits(res, 'try-error'))
```

which, in the case of failure, gives a message like:
> Error: inherits(res, "try-error") isn't false

I propose instead:
```R
expect_try(expr)
```

which I find much cleaner.
Furthermore, in the case of failure, the message is also cleaner:
> Error: stop() threw an error
