### PR TITLE
Add error handling for test_file

### DIFF
--- a/R/test-files.r
+++ b/R/test-files.r
@@ -155,7 +155,19 @@ test_file <- function(path, reporter = "summary", env = test_env(),
   fname <- basename(path)
   lister$start_file(fname)
 
-  sys.source2(fname, new.env(parent = env))
+  tryCatch({
+    sys.source2(fname, new.env(parent = env))
+  }, error = function(e){
+    context(fname)
+    
+    warning(
+      paste0("File sourcing failed, likely due to either an error in untested code ",
+             "or a malformed file name"))
+    
+    fail("File Sourcing Failed")
+    end_context()
+  })
+
   end_context()
 
   if (start_end_reporter) reporter$end_reporter()

--- a/tests/testthat/test-line_numbers.r
+++ b/tests/testthat/test-line_numbers.r
@@ -3,34 +3,34 @@ context("Line Numbers")
 test_that("line numbers are found and given to reporters", {
     ## a reporter that keeps its results
   GreedyReporter <- setRefClass("GreedyReporter", contains = "Reporter",
-      where = environment(), 
+      where = environment(),
       fields = list(results = "list"),
       methods = list(
           add_result = function(result) {
               results[[length(results) + 1]] <<- result
          }
     ))
-  
+
   # get the results supplied to the reporter by expectations
   .test_code <- function(code, reporter = GreedyReporter$new(),
                         path = tempfile(fileext = ".R")) {
     code <- sub("^\\n", '', code) # strip first empty line if any
     writeLines(code, path)
     on.exit(unlink(path))
-    
+
     test_file(path, reporter)
     reporter$results
   }
-    
+
   .test_and_fetch_lines <- function(code) {
     vapply(.test_code(code), function(x) x$srcref[1], 1L)
   }
 
   ### ==== EDGE CASES ====
-  
+
   # test file with errors, e.g. unknown function
-  expect_error(.test_code('expect_toto()'), regexp = 'Error')
-  
+  expect_warning(.test_code('expect_toto()'), regexp = 'File sourcing')
+
   # no errors are thrown inside test_that: test_that swallows errors
   code <- "
     test_that('simple', {      # line1
@@ -39,23 +39,23 @@ test_that("line numbers are found and given to reporters", {
   "
   res1 <- .test_code(code)[[1]]
   expect_true(res1$error && is.null(res1$srcref))
-  
+
   #  unparsable test file
-  expect_error(.test_code( 'bla)('))
-  
+  expect_warning(.test_code( 'bla)('), regexp = 'File sourcing')
+
   # no tests
   res <- .test_code('1 + 1')
   expect_true(length(res) == 0)
-  
+
   # test_that with no tests
   res <- .test_code('test_that("void", 1+1)')
   expect_true(length(res) == 0)
-  
+
   # test without a test_that
   expect_equal(.test_and_fetch_lines('expect_true(FALSE)'),  1)
-  
+
   ### ==== NORMAL CASES ====
-  
+
   # simple
   code  <- "
   	context('testing testFile')    # line1
@@ -69,27 +69,27 @@ test_that("line numbers are found and given to reporters", {
   code  <- "
 		test_that('simple', {			             # line1
     	suppressMessages(expect_true(FALSE)) # line2
-    })								
+    })
   "
   expect_equal(.test_and_fetch_lines(code), 2)
-  
+
   #  the expect_true is not called
   code  <- "
     test_that('simple', {							# line1
     	if (1 == 2) expect_true(TRUE)		# line2
-    })								
+    })
   "
   res <- .test_code(code)
   expect_true(length(res) == 0)
-  
+
   # in a loop
   code  <- "
     test_that('simple', {					     # line1
     	for(i in 1:4) expect_true(TRUE)	 # line2
-    })								
+    })
     "
   expect_equal(.test_and_fetch_lines(code), rep(2,4))
- 
+
   # use case
   code  <- "
     context('testing testFile')    	# line1


### PR DESCRIPTION
I was running in to problems with a test suite that relied on running test_dir, errors in the test files that exist outside of any particular test caused the whole suite to stop. The proposed change allows the suite to continue running while reporting an error for the broken test file.