### PR TITLE
compare.numeric() message fix for names and attributes

### DIFF
--- a/R/compare.r
+++ b/R/compare.r
@@ -140,6 +140,12 @@ str_chunk <- function(x, length) {
 #' # as all.equal.
 #' compare(x, x + 1e-9)
 compare.numeric <- function(x, y, ..., max_diffs = 10) {
+  equal <- attr.all.equal(x, y, ...)
+  if (!is.null(equal)) {
+    equal <- paste0(equal, collapse='\n')
+    return(comparison(FALSE, equal))
+  }
+
   equal <- all.equal(x, y, ...)
   if (isTRUE(equal)) return(comparison())
 

--- a/R/compare.r
+++ b/R/compare.r
@@ -140,10 +140,13 @@ str_chunk <- function(x, length) {
 #' # as all.equal.
 #' compare(x, x + 1e-9)
 compare.numeric <- function(x, y, ..., max_diffs = 10) {
-  equal <- attr.all.equal(x, y, ...)
-  if (!is.null(equal)) {
-    equal <- paste0(equal, collapse='\n')
-    return(comparison(FALSE, equal))
+  dots <- list(...)
+  if(!isTRUE(dots$check.attributes == FALSE)) {
+    equal <- attr.all.equal(x, y, ...)
+    if (!is.null(equal)) {
+      equal <- paste0(equal, collapse='\n')
+      return(comparison(FALSE, equal))
+    }
   }
 
   equal <- all.equal(x, y, ...)

--- a/R/expectations-equality.R
+++ b/R/expectations-equality.R
@@ -41,9 +41,9 @@
 #'   scale = expectedValue)
 #' }
 #'
-#' # expect_equivalent ignores attributes (which does not include names)
+#' # expect_equivalent ignores attributes
 #' a <- b <- 1:3
-#' attr(b, 'foo') <- letters[1:3]
+#' names(b) <- letters[1:3]
 #' expect_equivalent(a, b)
 #' @name equivalence
 NULL

--- a/R/expectations-equality.R
+++ b/R/expectations-equality.R
@@ -41,9 +41,9 @@
 #'   scale = expectedValue)
 #' }
 #'
-#' # expect_equivalent ignores attributes
+#' # expect_equivalent ignores attributes (which does not include names)
 #' a <- b <- 1:3
-#' names(b) <- letters[1:3]
+#' attr(b, 'foo') <- letters[1:3]
 #' expect_equivalent(a, b)
 #' @name equivalence
 NULL

--- a/tests/testthat/test-mock.r
+++ b/tests/testthat/test-mock.r
@@ -38,12 +38,17 @@ test_that("multi-mock", {
 
 test_that("nested mock", {
   with_mock(
-    all.equal = function(x, y, ...) TRUE,
+    attr.all.equal = function(x, y, ...) NULL,
     {
       with_mock(
-        gives_warning = throws_error,
+        all.equal = function(x, y, ...) TRUE,
         {
-          expect_warning(stopifnot(!compare(3, "a")$equal))
+          with_mock(
+            gives_warning = throws_error,
+            {
+              expect_warning(stopifnot(!compare(3, "a")$equal))
+            }
+          )
         }
       )
     },
@@ -57,6 +62,7 @@ test_that("qualified mock names", {
   with_mock(
     gives_warning = throws_error,
     `base::all.equal` = function(x, y, ...) TRUE,
+    `base::attr.all.equal` = function(x, y, ...) NULL,
     {
       expect_warning(stopifnot(!compare(3, "a")$equal))
     }
@@ -64,6 +70,7 @@ test_that("qualified mock names", {
   with_mock(
     `testthat::gives_warning` = throws_error,
     all.equal = function(x, y, ...) TRUE,
+    attr.all.equal = function(x, y, ...) NULL,
     {
       expect_warning(stopifnot(!compare(3, "a")$equal))
     },


### PR DESCRIPTION
I developed this fix before noticing that a similar fix is already available for pulling at #313. I'm still sending this pull request just in case this approach is preferable for some reason.