### PR TITLE
Fix failure_msg and success_msg for throws_error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat 0.11.0.9000
 
+* Fix failure message for `throws_error` in case where no error is raised.
+
 * Added [Catch](https://github.com/philsquared/Catch) for unit testing of C++ code.
   See `?use_catch()` for more details. (@kevinushey)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # testthat 0.11.0.9000
 
-* Fix failure message for `throws_error` in case where no error is raised.
+* Fix failure message for `throws_error` in case where no error is raised (@nealrichardson, #342).
 
 * Added [Catch](https://github.com/philsquared/Catch) for unit testing of C++ code.
   See `?use_catch()` for more details. (@kevinushey)

--- a/R/expectations-matches.R
+++ b/R/expectations-matches.R
@@ -138,8 +138,8 @@ throws_error <- function(regexp = NULL, ...) {
     if (no_error) {
       return(expectation(
         identical(regexp, NA),
-        "code raised an error",
-        "code didn't raise an error"
+        "code didn't raise an error",
+        "code raised an error"
       ))
     }
 

--- a/tests/testthat/test-expectations.r
+++ b/tests/testthat/test-expectations.r
@@ -14,6 +14,7 @@ test_that("errors are caught with throws_error", {
 test_that("failure to throw an error is a failure", {
   res <- throws_error()(log(1))
   expect_that(res$passed, is_false())
+  expect_output(res, "code didn't raise an error")
 
   res <- throws_error("error")(log(1))
   expect_that(res$passed, is_false())


### PR DESCRIPTION
I noticed that `expect_error` was oddly printing that the "code raised an error" when the expectation correctly failed on code that did not error. Turns out the `failure_msg` and `success_msg` arguments were in the wrong order in `throws_error`. Test and fix.