### PR TITLE
Summary of skipped tests

### DIFF
--- a/R/reporter-check.R
+++ b/R/reporter-check.R
@@ -78,6 +78,14 @@ CheckReporter <- setRefClass("CheckReporter", contains = "Reporter",
   )
 )
 
+skip_summary <- function(x, label) {
+  header <- paste0(label, ". ", x$test)
+
+  paste0(
+    colourise(header, "skipped"), " - ", x$failure_msg
+  )
+}
+
 failure_summary <- function(x, label, width = getOption("width")) {
   header <- paste0(label, ". ", failure_header(x))
   linewidth <- ifelse(nchar(header) > width, 0, width - nchar(header))

--- a/R/reporter-check.R
+++ b/R/reporter-check.R
@@ -90,7 +90,12 @@ failure_summary <- function(x, label, width = getOption("width")) {
 }
 
 failure_header <- function(x) {
-  type <- if (x$error) "Error" else "Failure"
+  if (x$skipped)
+    type <- "Skip"
+  else if (x$error)
+    type <- "Error"
+  else
+    type <- "Failure"
 
   ref <- x$srcref
   if (is.null(ref)) {

--- a/R/reporter-check.R
+++ b/R/reporter-check.R
@@ -98,9 +98,7 @@ failure_summary <- function(x, label, width = getOption("width")) {
 }
 
 failure_header <- function(x) {
-  if (x$skipped)
-    type <- "Skip"
-  else if (x$error)
+  if (x$error)
     type <- "Error"
   else
     type <- "Failure"

--- a/R/reporter-summary.r
+++ b/R/reporter-summary.r
@@ -80,10 +80,13 @@ SummaryReporter <- setRefClass("SummaryReporter", contains = "Reporter",
         if (!has_tests)
           return()
 
-        reports <- vapply(seq_along(skips), function(i) {
-          failure_summary(skips[[i]], labels[i])
-        }, character(1))
-        cat(paste(reports, collapse = "\n\n"), "\n", sep = "")
+        if (length(skips) > 0L) {
+          cat(colourise("\nSkip:", "skipped"), "\n\n")
+          reports <- vapply(seq_along(skips), function(i) {
+            skip_summary(skips[[i]], labels[i])
+          }, character(1L))
+          cat(paste(reports, collapse = "\n"), "\n", sep = "")
+        }
 
         cat("\n")
         if (show_praise && runif(1) < 0.1) {

--- a/R/reporter-summary.r
+++ b/R/reporter-summary.r
@@ -23,6 +23,7 @@ NULL
 SummaryReporter <- setRefClass("SummaryReporter", contains = "Reporter",
   fields = list(
     "failures" = "list",
+    "skips" = "list",
     "n" = "integer",
     "has_tests" = "logical",
     "max_reports" = "numeric",
@@ -45,6 +46,7 @@ SummaryReporter <- setRefClass("SummaryReporter", contains = "Reporter",
 
     start_reporter = function() {
       failures <<- list()
+      skips <<- list()
       has_tests <<- FALSE
       n <<- 0L
     },
@@ -53,6 +55,8 @@ SummaryReporter <- setRefClass("SummaryReporter", contains = "Reporter",
       callSuper(result)
       has_tests <<- TRUE
       if (result$skipped) {
+        result$test <- if (is.null(test)) "(unknown)" else test
+        skips <<- c(skips, list(result))
         cat(colourise("S", "skipped"))
         return()
       }
@@ -75,6 +79,12 @@ SummaryReporter <- setRefClass("SummaryReporter", contains = "Reporter",
       if (n == 0) {
         if (!has_tests)
           return()
+
+        reports <- vapply(seq_along(skips), function(i) {
+          failure_summary(skips[[i]], labels[i])
+        }, character(1))
+        cat(paste(reports, collapse = "\n\n"), "\n", sep = "")
+
         cat("\n")
         if (show_praise && runif(1) < 0.1) {
           cat(colourise(praise(), "passed"), "\n")

--- a/R/reporter-summary.r
+++ b/R/reporter-summary.r
@@ -82,10 +82,7 @@ SummaryReporter <- setRefClass("SummaryReporter", contains = "Reporter",
 
         if (length(skips) > 0L) {
           cat(colourise("\nSkip:", "skipped"), "\n\n")
-          reports <- vapply(seq_along(skips), function(i) {
-            skip_summary(skips[[i]], labels[i])
-          }, character(1L))
-          cat(paste(reports, collapse = "\n"), "\n", sep = "")
+          cat_reports(skips, skip_summary, "\n")
         }
 
         cat("\n")


### PR DESCRIPTION
Shows skipped tests, but only if there are no failures. Example:

```
Testing bigrquery
DBItest: Connection : ..SS..S.SS
1. Skip: DBItest: cannot_query_disconnected --------------------------------------------------------------------------------------------------------------
Not yet implemented

2. Skip: DBItest: cannot_disconnect_twice ----------------------------------------------------------------------------------------------------------------
by request

3. Skip: DBItest: stress_connections ---------------------------------------------------------------------------------------------------------------------
by request

4. Skip: DBItest: get_info_connection --------------------------------------------------------------------------------------------------------------------
Not yet implemented

5. Skip: DBItest: stress_load_connect_unload -------------------------------------------------------------------------------------------------------------
by request

DONE 
```

Will improve the coding once we agree on the concept.

Fixes #234.

CC @HarlanH @kenahoo-windlogics

Fixes #349 (=includes it).