### PR TITLE
Limit number of reports printed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat 0.11.0.9000
 
+* New option `testthat.summary.max_reports` that limits the number of reports printed by the summary reporter, default: 15 (@krlmlr, #354).
+
 * Fix failure message for `throws_error` in case where no error is raised (@nealrichardson, #342).
 
 * Added [Catch](https://github.com/philsquared/Catch) for unit testing of C++ code.

--- a/R/reporter-summary.r
+++ b/R/reporter-summary.r
@@ -29,7 +29,7 @@ SummaryReporter <- setRefClass("SummaryReporter", contains = "Reporter",
     "show_praise" = "logical"),
 
   methods = list(
-    initialize = function(max_reports = Inf, ...) {
+    initialize = function(max_reports = getOption("testthat.summary.max_reports", 15L), ...) {
       max_reports <<- max_reports
       show_praise <<- TRUE
       callSuper(...)

--- a/R/test-that.r
+++ b/R/test-that.r
@@ -86,10 +86,10 @@ test_code <- function(description, code, env) {
 #'
 #' @section Options:
 #' \code{testthat.use_colours}: Should the output be coloured? (Default:
-#' \code {TRUE}).
+#' \code{TRUE}).
 #'
-#' \code{testthat.summary.max_results}: The maximum number of detailed test
-#' results printed for the summary reporter (default: 15).
+#' \code{testthat.summary.max_reports}: The maximum number of detailed test
+#' reports printed for the summary reporter (default: 15).
 #'
 #' @docType package
 #' @name testthat

--- a/R/test-that.r
+++ b/R/test-that.r
@@ -84,6 +84,13 @@ test_code <- function(description, code, env) {
 #' testthat is a new testing framework for R that is easy learn and use,
 #' and integrates with your existing workflow.
 #'
+#' @section Options:
+#' \code{testthat.use_colours}: Should the output be coloured? (Default:
+#' \code {TRUE}).
+#'
+#' \code{testthat.summary.max_results}: The maximum number of detailed test
+#' results printed for the summary reporter (default: 15).
+#'
 #' @docType package
 #' @name testthat
 #' @references Wickham, H (2011). testthat: Get Started with Testing.

--- a/man/testthat.Rd
+++ b/man/testthat.Rd
@@ -19,10 +19,10 @@ and integrates with your existing workflow.
 \section{Options}{
 
 \code{testthat.use_colours}: Should the output be coloured? (Default:
-\code {TRUE}).
+\code{TRUE}).
 
-\code{testthat.summary.max_results}: The maximum number of detailed test
-results printed for the summary reporter (default: 15).
+\code{testthat.summary.max_reports}: The maximum number of detailed test
+reports printed for the summary reporter (default: 15).
 }
 \examples{
 library(testthat)

--- a/man/testthat.Rd
+++ b/man/testthat.Rd
@@ -16,6 +16,14 @@ it is frustrating and boring, many of us avoid it.
 testthat is a new testing framework for R that is easy learn and use,
 and integrates with your existing workflow.
 }
+\section{Options}{
+
+\code{testthat.use_colours}: Should the output be coloured? (Default:
+\code {TRUE}).
+
+\code{testthat.summary.max_results}: The maximum number of detailed test
+results printed for the summary reporter (default: 15).
+}
 \examples{
 library(testthat)
 a <- 9


### PR DESCRIPTION
Default: 15, configurable via new option `testthat.summary.max_results`.

Fixes #353.