### PR TITLE
set_reporter() returns old reporter invisibly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,14 @@
 # testthat 0.11.0.9000
 
-* Fix failure message for `throws_error` in case where no error is raised (@nealrichardson, #342).
+* `set_reporter()` returns old reporter invisibly (#358, @krlmlr).
+
+* Fix failure message for `throws_error` in case where no error is raised (#342, @nealrichardson).
 
 * Added [Catch](https://github.com/philsquared/Catch) for unit testing of C++ code.
   See `?use_catch()` for more details. (@kevinushey)
 
 * `expect_identical()` and `is_identical_to()` now use `compare()` for more
-  detailed output of differences (@krlmlr, #319).
+  detailed output of differences (#319, @krlmlr).
 
 # testthat 0.11.0
 

--- a/R/reporter-zzz.r
+++ b/R/reporter-zzz.r
@@ -23,7 +23,7 @@ testthat_env$reporter <- StopReporter$new()
 set_reporter <- function(reporter) {
   old <- testthat_env$reporter
   testthat_env$reporter <- reporter
-  old
+  invisible(old)
 }
 
 #' @rdname reporter-accessors


### PR DESCRIPTION
to avoid surprises.