### PR TITLE
Rename failure_msg to message

### DIFF
--- a/R/expect-success-failure.R
+++ b/R/expect-success-failure.R
@@ -31,7 +31,7 @@ expect_failure <- function(expr, message = NULL, ...) {
     if (is.null(message)) {
       expect(!exp$passed, "expectation succeeded")
     } else {
-      expect_match(exp$failure_msg, message, ...)
+      expect_match(exp$message, message, ...)
     }
   }
 }

--- a/R/expectation.r
+++ b/R/expectation.r
@@ -5,16 +5,16 @@
 #'
 #' @param passed a single logical value indicating whether the test passed
 #'  (\code{TRUE}), failed (\code{FALSE}), or threw an error (\code{NA})
-#' @param failure_msg A text description of failure
+#' @param message A text description of failure
 #' @param srcref Source reference, if known
 #' @keywords internal
 #' @export
-expectation <- function(passed, failure_msg, srcref = NULL) {
-  new_expectation(passed = passed, failure_msg = failure_msg,
+expectation <- function(passed, message, srcref = NULL) {
+  new_expectation(passed = passed, message = message,
                   srcref = srcref)
 }
 
-new_expectation <- function(failure_msg, srcref, ...,
+new_expectation <- function(message, srcref, ...,
                             passed = FALSE, error = FALSE, skipped = FALSE) {
   if (passed) {
     class = c("expectation", "condition")
@@ -27,7 +27,7 @@ new_expectation <- function(failure_msg, srcref, ...,
       passed = passed,
       error = error,
       skipped = skipped,
-      failure_msg = failure_msg
+      message = message
     ),
     class = class
   )
@@ -39,15 +39,12 @@ update_expectation <- function(exp, srcref, info = NULL, label = NULL) {
   exp$srcref <- srcref
 
   if (!is.null(label)) {
-    exp$failure_msg <- paste0(label, " ", exp$failure_msg)
+    exp$message <- paste0(label, " ", exp$message)
   }
 
   if (!is.null(info)) {
-    exp$failure_msg <- paste0(exp$failure_msg, "\n", info)
+    exp$message <- paste0(exp$message, "\n", info)
   }
-
-  # TODO: Get rid of failure_msg in favor of message
-  exp$message <- exp$failure_msg
 
   exp
 }
@@ -70,7 +67,7 @@ as.expectation.expectation <- function(x, ...) x
 
 #' @export
 as.expectation.logical <- function(x, message, ...) {
-  expectation(passed = x, failure_msg = message, srcref = find_test_srcref())
+  expectation(passed = x, message = message, srcref = find_test_srcref())
 }
 
 #' @export
@@ -117,7 +114,7 @@ format.expectation <- function(x, ...) {
   if (x$passed) {
     "As expected"
   } else {
-    paste0("Not expected: ", x$failure_msg, ".")
+    paste0("Not expected: ", x$message, ".")
   }
 }
 
@@ -132,7 +129,7 @@ negate <- function(expt) {
 
   opp <- expt
   opp$passed <- !expt$passed
-  opp$failure_msg <- paste0("NOT(", opp$failure_msg, ")")
+  opp$message <- paste0("NOT(", opp$message, ")")
   opp
 
 }

--- a/R/reporter-check.R
+++ b/R/reporter-check.R
@@ -82,7 +82,7 @@ skip_summary <- function(x, label) {
   header <- paste0(label, ". ", x$test)
 
   paste0(
-    colourise(header, "skipped"), " - ", x$failure_msg
+    colourise(header, "skipped"), " - ", x$message
   )
 }
 
@@ -93,7 +93,7 @@ failure_summary <- function(x, label, width = getOption("width")) {
 
   paste0(
     colourise(header, "error"), line, "\n",
-    x$failure_msg
+    x$message
   )
 }
 

--- a/R/reporter-rstudio.R
+++ b/R/reporter-rstudio.R
@@ -37,7 +37,7 @@ RstudioReporter <- setRefClass("RstudioReporter", contains = "Reporter",
         location <- paste0(attr(ref, "srcfile")$filename, "#", ref[1], ":1")
       }
 
-      cat(location, " [", status, "] ", test, ". ", strsplit(result$failure_msg, "\n")[[1]][1], "\n",
+      cat(location, " [", status, "] ", test, ". ", strsplit(result$message, "\n")[[1]][1], "\n",
         sep = "")
     }
   )

--- a/R/reporter-stop.r
+++ b/R/reporter-stop.r
@@ -50,7 +50,7 @@ StopReporter <- setRefClass("StopReporter", contains = "Reporter",
 
       # If running in test suite, store, otherwise raise immediately.
       if (is.null(test)) {
-        stop(result$failure_msg, call. = FALSE)
+        stop(result$message, call. = FALSE)
       } else {
         failures <<- c(failures, list(result))
       }

--- a/R/reporter-tap.r
+++ b/R/reporter-tap.r
@@ -52,10 +52,10 @@ TapReporter <- setRefClass("TapReporter", contains = "Reporter",
                 if (result$passed) {
                     cat('ok', i, result$test, '\n')
                 } else if (result$skipped) {
-                    cat('ok', i, '# SKIP', result$failure_msg, '\n')
+                    cat('ok', i, '# SKIP', result$message, '\n')
                 } else {
                     cat('not ok', i, result$test, '\n')
-                    msg <- gsub('\n', '\n  ', result$failure_msg)
+                    msg <- gsub('\n', '\n  ', result$message)
                     cat(' ', msg, '\n')
                 }
             }

--- a/R/reporter-teamcity.r
+++ b/R/reporter-teamcity.r
@@ -50,14 +50,14 @@ TeamcityReporter <- setRefClass("TeamcityReporter", contains = "Reporter",
       testName <- paste0("expectation ", i)
 
       if (result$skipped) {
-        teamcity("testIgnored", testName, message = result$failure_msg)
+        teamcity("testIgnored", testName, message = result$message)
         return()
       }
 
       teamcity("testStarted", testName)
 
       if (!result$passed) {
-        lines <- strsplit(result$failure_msg, "\n")[[1]]
+        lines <- strsplit(result$message, "\n")[[1]]
 
         teamcity("testFailed", testName, message = lines[1],
           details = paste(lines[-1], collapse = "\n")

--- a/man/expectation.Rd
+++ b/man/expectation.Rd
@@ -5,7 +5,7 @@
 \alias{is.expectation}
 \title{Expectation class.}
 \usage{
-expectation(passed, failure_msg, srcref = NULL)
+expectation(passed, message, srcref = NULL)
 
 is.expectation(x)
 }
@@ -13,7 +13,7 @@ is.expectation(x)
 \item{passed}{a single logical value indicating whether the test passed
 (\code{TRUE}), failed (\code{FALSE}), or threw an error (\code{NA})}
 
-\item{failure_msg}{A text description of failure}
+\item{message}{A text description of failure}
 
 \item{srcref}{Source reference, if known}
 


### PR DESCRIPTION
because "message" is also the default field in condition objects.