### PR TITLE
Don't duplicate "error" class

### DIFF
--- a/R/expectation.r
+++ b/R/expectation.r
@@ -22,7 +22,7 @@ expectation <- function(type, message, srcref = NULL) {
     class = c(
       "expectation",
       type,
-      if (type %in% c("failure", "error")) "error",
+      if (type == "failure") "error",
       "condition"
     )
   )


### PR DESCRIPTION
If type == "error", the "error" class doesn't need to be added