### PR TITLE
Discussion: Don't use class "error" for failures?

### DIFF
--- a/R/expectation.R
+++ b/R/expectation.R
@@ -22,7 +22,8 @@ expectation <- function(type, message, srcref = NULL) {
     class = c(
       "expectation",
       type,
-      if (type == "failure") "error",
+      # Failures cannot have class "error", otherwise each failed expectation
+      # inside expect_error() aborts the test
       "condition"
     )
   )

--- a/R/expectation.R
+++ b/R/expectation.R
@@ -22,8 +22,6 @@ expectation <- function(type, message, srcref = NULL) {
     class = c(
       "expectation",
       type,
-      # Failures cannot have class "error", otherwise each failed expectation
-      # inside expect_error() aborts the test
       "condition"
     )
   )

--- a/R/try-again.R
+++ b/R/try-again.R
@@ -26,6 +26,9 @@ try_again <- function(times, code) {
           }
         }
       ),
+      failure = function(e) {
+        e
+      },
       error = function(e) {
         e
       }

--- a/tests/testthat/test-bare.R
+++ b/tests/testthat/test-bare.R
@@ -6,9 +6,9 @@ expect_error(stop("!"))
 
 stopifnot(
   tryCatch(expect_true(TRUE),
-           error = function(e) FALSE)
+           failure = function(e) FALSE)
 )
 stopifnot(
   tryCatch(expect_true(FALSE),
-           error = function(e) TRUE)
+           failure = function(e) TRUE)
 )

--- a/tests/testthat/test-test-that.R
+++ b/tests/testthat/test-test-that.R
@@ -22,6 +22,18 @@ test_that("errors captured even when looking for warnings", {
   expect_equal(length(reporter$expectations()), 1)
 })
 
+test_that("multiple failures captured even when looking for errors", {
+  f <- function() {
+    expect_true(FALSE)
+    expect_false(TRUE)
+  }
+
+  reporter <- with_reporter("silent", {
+    test_that("", expect_error(f(), NA))
+  })
+  expect_equal(length(reporter$expectations()), 3)
+})
+
 test_that("return value from test_that", {
   with_reporter("", success <- test_that("success", {}))
   expect_true(success)


### PR DESCRIPTION
Follow-up to https://github.com/hadley/testthat/pull/375#issuecomment-187375108

Currently, the following code executes only the first expectation:

```
test_that("expect", {
  multi <- function() {
    expect_true(FALSE)
    expect_false(TRUE)
  }

  expect_error(multi(), NA)
})
```

(Added to the regression tests.)

This PR resolves this, and also the problems seen in https://github.com/hadley/testthat/pull/379#issuecomment-190721317. I've tried changing the implementation of expect_error() to no avail.

On the other hand, this behavior is not wrong if failures are explicitly considered as errors.