### PR TITLE
reverse class order

### DIFF
--- a/R/expectation.R
+++ b/R/expectation.R
@@ -17,11 +17,9 @@ expectation <- function(type, message, srcref = NULL) {
       message = message,
       srcref = srcref
     ),
-    # Use "expectation" as top-level class so that no coercion is applied
-    # to expectation objects by as.expectation()
     class = c(
+      paste0("expectation_", type),
       "expectation",
-      type,
       "condition"
     )
   )
@@ -75,7 +73,8 @@ label <- function(obj) {
 }
 
 expectation_type <- function(exp) {
-  class(exp)[[which(class(exp) == "expectation") + 1L]]
+  cl <- class(exp)[[grep("^expectation_", class(exp))[[1L]] ]]
+  gsub("^expectation_", "", cl)
 }
 
 expectation_success <- function(exp) {

--- a/R/try-again.R
+++ b/R/try-again.R
@@ -26,7 +26,7 @@ try_again <- function(times, code) {
           }
         }
       ),
-      failure = function(e) {
+      expectation_failure = function(e) {
         e
       },
       error = function(e) {

--- a/tests/testthat/test-bare.R
+++ b/tests/testthat/test-bare.R
@@ -6,9 +6,9 @@ expect_error(stop("!"))
 
 stopifnot(
   tryCatch(expect_true(TRUE),
-           failure = function(e) FALSE)
+           expectation_failure = function(e) FALSE)
 )
 stopifnot(
   tryCatch(expect_true(FALSE),
-           failure = function(e) TRUE)
+           expectation_failure = function(e) TRUE)
 )


### PR DESCRIPTION
re https://github.com/hadley/testthat/pull/387/files#r54641381

All expectation classes now have an `expectation_` prefix.