### PR TITLE
Test that functions are exported from the package namespace

### DIFF
--- a/R/test-files.R
+++ b/R/test-files.R
@@ -23,16 +23,17 @@ test_env <- function() {
 #'   regular expression will be executed.  Matching will take on the file
 #'   name after it has been stripped of \code{"test-"} and \code{".R"}.
 #' @param env environment in which to execute test suite.
+#' @param start_end_reporter whether to start and end the reporter
 #' @param ... Additional arguments passed to \code{grepl} to control filtering.
 #'
 #' @return the results as a "testthat_results" (list)
 #' @export
 test_dir <- function(path, filter = NULL, reporter = "summary",
-                                          env = test_env(), ...) {
+                     env = test_env(), start_end_reporter=TRUE, ...) {
   source_test_helpers(path, env)
   paths <- find_test_scripts(path, filter, ...)
 
-  test_files(paths, reporter = reporter, env = env, ...)
+  test_files(paths, reporter = reporter, env = env, start_end_reporter=start_end_reporter, ...)
 }
 
 test_files <- function(paths, reporter = "summary",
@@ -51,7 +52,8 @@ test_files <- function(paths, reporter = "summary",
       reporter = current_reporter,
       start_end_reporter = FALSE,
       load_helpers = FALSE
-    )
+    ),
+    ...
   )
 
   results <- unlist(results, recursive = FALSE)

--- a/R/test-package.R
+++ b/R/test-package.R
@@ -59,14 +59,20 @@ test_package <- function(package, filter = NULL, reporter = "summary", ...) {
 }
 
 
-run_tests <- function(package, test_path, filter, reporter, ...)
-{
+run_tests <- function(package, test_path, filter, reporter, ...) {
   reporter <- find_reporter(reporter)
   env <- test_pkg_env(package)
-  res <- with_top_env(env, {
-    test_dir(test_path, reporter = reporter, env = env, filter = filter, ...)
+  with_reporter(reporter, {
+    res <- with_top_env(env, {
+      test_dir(test_path, reporter = reporter, env = env, filter = filter,
+        start_end_reporter=FALSE, ...)
+    })
+    public_dir <- file.path(test_path, "public")
+    if (dir.exists(public_dir)) {
+        res <- c(res, test_dir(public_dir, reporter = reporter,
+          env = globalenv(), filter = filter, start_end_reporter=FALSE, ...))
+    }
   })
-
   if (!all_passed(res)) {
     stop("Test failures", call. = FALSE)
   }

--- a/R/test-package.R
+++ b/R/test-package.R
@@ -69,8 +69,11 @@ run_tests <- function(package, test_path, filter, reporter, ...) {
     })
     public_dir <- file.path(test_path, "public")
     if (dir.exists(public_dir)) {
-        res <- c(res, test_dir(public_dir, reporter = reporter,
-          env = globalenv(), filter = filter, start_end_reporter=FALSE, ...))
+      # Check for a "public" subdirectory. If found, run its tests in the
+      # global environment, not in the package namespace. Append to the test
+      # results from the non-public tests.
+      res <- c(res, test_dir(public_dir, reporter = reporter,
+        env = globalenv(), filter = filter, start_end_reporter=FALSE, ...))
     }
   })
   if (!all_passed(res)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -65,3 +65,5 @@ f_name <- function(x) {
     ""
   }
 }
+
+.function_not_exported <- function () TRUE

--- a/man/test_dir.Rd
+++ b/man/test_dir.Rd
@@ -4,7 +4,8 @@
 \alias{test_dir}
 \title{Run all of the tests in a directory.}
 \usage{
-test_dir(path, filter = NULL, reporter = "summary", env = test_env(), ...)
+test_dir(path, filter = NULL, reporter = "summary", env = test_env(),
+  start_end_reporter = TRUE, ...)
 }
 \arguments{
 \item{path}{path to tests}
@@ -16,6 +17,8 @@ name after it has been stripped of \code{"test-"} and \code{".R"}.}
 \item{reporter}{reporter to use}
 
 \item{env}{environment in which to execute test suite.}
+
+\item{start_end_reporter}{whether to start and end the reporter}
 
 \item{...}{Additional arguments passed to \code{grepl} to control filtering.}
 }

--- a/tests/testthat/public/helper.R
+++ b/tests/testthat/public/helper.R
@@ -1,0 +1,1 @@
+public.var <- 42

--- a/tests/testthat/public/test-exported.R
+++ b/tests/testthat/public/test-exported.R
@@ -1,0 +1,10 @@
+context("Exported functions")
+
+test_that("Running the public tests runs its helper", {
+  expect_identical(public.var, 42)
+})
+
+test_that("Functions that aren't exported can't be found in public context", {
+  expect_error(.function_not_exported(),
+    'could not find function ".function_not_exported"')
+})

--- a/tests/testthat/test-public.R
+++ b/tests/testthat/test-public.R
@@ -1,0 +1,5 @@
+context("Testing non-exported functions")
+
+test_that("test_check evaluates in package namespace", {
+  expect_true(.function_not_exported())
+})


### PR DESCRIPTION
More times than I'd like to admit, I've added new functions to a package and forgotten to export them from the namespace. It's really easy to do because `test_check` runs tests inside the package namespace. That's great for unit testing, but it's less helpful for validating the package interface being provided to your users. 

In the interest of avoiding past mistakes, in the [httpcache](https://github.com/nealrichardson/httpcache) package tests, I experimented with a `public` context that evaluates test code in the global environment, rather than the package environment: 

    public <- function (...) with(globalenv(), ...)

It had the [desired effect](https://github.com/nealrichardson/httpcache/blob/master/tests/testthat/test-zzz-helper.R#L3-L12) in that only exported functions could be found inside a `public()` block, so it would fail if I had failed to document and export something. But, I found that I was wrapping entire test files in `public({...})`, which was a bit repetitive. And it was still a little too manual, and thus forgettable. I wanted something that would be more foolproof and obvious.

So, I made a few tweaks to `run_tests` and `test_files`, such that if there is a subdirectory in your test path called "public", the code/tests in it will be run in the global environment rather than the package environment. The two main changes are (1) the check for that "public" directory and running `test_dir` in it, and (2) passing the `start_end_reporter` argument around a couple more places so that `run_tests` could call `test_dir` twice with the same reporter. The added tests assert that non-exported functions aren't visible in the public tests. 

Since this seemed like a solution to a problem that others may have, I figured I'd submit the pull request for your consideration. Happy to rework it if you see a better way to achieve this, and open to renaming if "public" doesn't seem like the right label.