### PR TITLE
NULL reporter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -107,7 +107,9 @@ The reporters system class has been considerably refactored to make existing rep
   (#307, @krlmlr).
 
 * `with_reporter()` is used internally and gains new argument 
-  `start_end_reporter = TRUE` (@krlmlr, 355).
+  `start_end_reporter = TRUE` (#355, @krlmlr). If passed `NULL`, the active reporter
+  is not changed (#404, @krlmlr); this allows running the tests for other
+  packages.
 
 * `set_reporter()` returns old reporter invisibly (#358, @krlmlr).
 

--- a/R/reporter-zzz.R
+++ b/R/reporter-zzz.R
@@ -41,8 +41,17 @@ get_reporter <- function() {
 with_reporter <- function(reporter, code, start_end_reporter = TRUE) {
   reporter <- find_reporter(reporter)
 
-  old <- set_reporter(reporter)
-  on.exit(set_reporter(old), add = TRUE)
+  if (!is.null(reporter)) {
+    old <- set_reporter(reporter)
+    on.exit(set_reporter(old), add = TRUE)
+  } else {
+    reporter <- get_reporter()
+    if (is.null(reporter)) {
+      stop("Need active reporter if calling with_reporter(NULL, ...).",
+           call. = FALSE)
+    }
+    start_end_reporter <- FALSE
+  }
 
   if (start_end_reporter) {
     reporter$start_reporter()

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -100,6 +100,9 @@ test_file <- function(path, reporter = "summary", env = test_env(),
   library(testthat)
 
   reporter <- find_reporter(reporter)
+  if (is.null(reporter)) {
+    reporter <- get_reporter()
+  }
 
   if (load_helpers) {
     source_test_helpers(dirname(path), env = env)

--- a/tests/testthat/test-reporter.R
+++ b/tests/testthat/test-reporter.R
@@ -7,6 +7,7 @@ test_that("can locate reporter from name", {
   expect_that(find_reporter("list"),    equals(ListReporter$new()))
   expect_that(find_reporter("multi"),   equals(MultiReporter$new()))
   expect_that(find_reporter(""),        equals(Reporter$new()))
+  expect_that(find_reporter(NULL),      is_null)
 })
 
 test_that("useful error message if can't find reporter", {

--- a/tests/testthat/test-reporter.R
+++ b/tests/testthat/test-reporter.R
@@ -7,7 +7,7 @@ test_that("can locate reporter from name", {
   expect_that(find_reporter("list"),    equals(ListReporter$new()))
   expect_that(find_reporter("multi"),   equals(MultiReporter$new()))
   expect_that(find_reporter(""),        equals(Reporter$new()))
-  expect_that(find_reporter(NULL),      is_null)
+  expect_that(find_reporter(NULL),      is_null())
 })
 
 test_that("useful error message if can't find reporter", {


### PR DESCRIPTION
Does nothing in with_reporter(), provided that an active reporter exists.

Needed for dplyr testing as part of the dtplyr tests.