### PR TITLE
Broken test: labelling if function value has been forced

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # testthat 0.11.0.9000
 
+## Breaking changes
+
+The `expectation()` function now expects an expectation type (one of "success", "failure", "error", "skip", "warning") as first argument. Use `expect_true()` function instead.
+
+
 ## New expectations
 
 The expectation system got a thorough overhaul (#217). This primarily makes it easier to add new expectations in the future, but also included a thorough review of the documentation, ensuring that related expectations are documented together, and have evocative names.
@@ -40,6 +45,7 @@ A number of older features have been deprecated:
 
 * `not()` has been deprecated. Please use the explicit individual forms
   `expect_error(..., NA)` , `expect_warning(.., NA)` and so on.
+
 
 ## Expectations are conditions
 

--- a/R/auto-test.R
+++ b/R/auto-test.R
@@ -38,7 +38,7 @@ auto_test <- function(code_path, test_path, reporter = "summary",
 
   # Start by loading all code and running all tests
   source_dir(code_path, env = env)
-  test_dir(test_path, env = env, reporter = reporter$copy())
+  test_dir(test_path, env = env, reporter = reporter$clone())
 
   # Next set up watcher to monitor changes
   watcher <- function(added, deleted, modified) {
@@ -52,11 +52,11 @@ auto_test <- function(code_path, test_path, reporter = "summary",
       cat("Changed code: ", paste0(basename(code), collapse = ", "), "\n")
       cat("Rerunning all tests\n")
       source_dir(code_path, env = env)
-      test_dir(test_path, env = env, reporter = reporter$copy())
+      test_dir(test_path, env = env, reporter = reporter$clone())
     } else if (length(tests) > 0) {
       # If test changes, rerun just that test
       cat("Rerunning tests: ", paste0(basename(tests), collapse = ", "), "\n")
-      test_files(tests, env = env, reporter = reporter$copy())
+      test_files(tests, env = env, reporter = reporter$clone())
     }
 
     TRUE
@@ -88,7 +88,7 @@ auto_test_package <- function(pkg = ".", reporter = "summary") {
   env <- devtools::load_all(pkg)$env
   devtools::with_envvar(
     devtools::r_env_vars(),
-    test_dir(test_path, env = env, reporter = reporter$copy())
+    test_dir(test_path, env = env, reporter = reporter$clone())
   )
 
   # Next set up watcher to monitor changes
@@ -105,14 +105,14 @@ auto_test_package <- function(pkg = ".", reporter = "summary") {
       env <<- devtools::load_all(pkg, quiet = TRUE)$env
       devtools::with_envvar(
         devtools::r_env_vars(),
-        test_dir(test_path, env = env, reporter = reporter$copy())
+        test_dir(test_path, env = env, reporter = reporter$clone())
       )
     } else if (length(tests) > 0) {
       # If test changes, rerun just that test
       cat("Rerunning tests: ", paste0(basename(tests), collapse = ", "), "\n")
       devtools::with_envvar(
         devtools::r_env_vars(),
-        test_files(tests, env = env, reporter = reporter$copy())
+        test_files(tests, env = env, reporter = reporter$clone())
       )
     }
 

--- a/R/mock.R
+++ b/R/mock.R
@@ -41,7 +41,8 @@ with_mock <- function(..., .env = topenv()) {
   mock_qual_names <- names(new_values)
 
   if (all(mock_qual_names == "")) {
-    warning("Not mocking anything. Please use named parameters to specify the functions you want to mock.")
+    warning("Not mocking anything. Please use named parameters to specify the functions you want to mock.",
+            call. = FALSE)
     code_pos <- TRUE
   } else {
     code_pos <- (mock_qual_names == "")
@@ -85,7 +86,7 @@ extract_mocks <- function(new_values, .env, eval_env = parent.frame()) {
 
       if (!exists(name, envir = env, mode = "function"))
         stop("Function ", name, " not found in environment ",
-             environmentName(env), ".")
+             environmentName(env), ".", call. = FALSE)
       mock(name = name, env = env, new = eval(new_values[[qual_name]], eval_env, eval_env))
     }
   )

--- a/tests/testthat/test-label.R
+++ b/tests/testthat/test-label.R
@@ -6,3 +6,12 @@ test_that("labelling compound {} expression gives single string", {
   expect_length(out, 1)
   expect_type(out, "character")
 })
+
+test_that("labelling in called function works if value is forced", {
+  f <- function(v) {
+    force(v)
+    expect_equal(v, v)
+  }
+
+  for (v in 1:5) f(v)
+})


### PR DESCRIPTION
This occurred in one of the existing tests in RSQLite. @hadley: PTAL.