### PR TITLE
Exclude catch code from coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ r_github_packages:
   - jimhester/covr@v2
 
 after_success:
-  - Rscript -e 'covr::codecov()'
+  - Rscript -e 'covr::codecov(line_exclusions = c("inst/include/testthat/testthat.h", "inst/include/testthat/vendor/catch.h"))'


### PR DESCRIPTION
The coverage is lower than expected because of the external dependency (https://codecov.io/github/hadley/testthat?ref=101b32da1e9b757212c07ca9f58a0eac8075e068)

We can exclude those files however!