### PR TITLE
implement standalone signal mechanism for reporters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,6 +62,7 @@ Collate:
     'reporter-tap.R'
     'reporter-teamcity.R'
     'reporter-zzz.R'
+    'signals.R'
     'skip.R'
     'source.R'
     'test-compiled-code.R'

--- a/R/expectation.R
+++ b/R/expectation.R
@@ -37,6 +37,7 @@ expect <- function(exp, ..., srcref = NULL) {
       stop(exp)
     } else {
       signalCondition(exp)
+      signal_fire("expectation", exp)
     },
     continue_test = function(e) NULL
   )

--- a/R/signals.R
+++ b/R/signals.R
@@ -1,0 +1,27 @@
+.__HANDLERS__. <- new.env(parent = emptyenv())
+
+signal_handlers_get <- function(signal) {
+  if (!exists(signal, envir = .__HANDLERS__.))
+    assign(signal, new.env(parent = emptyenv()), envir = .__HANDLERS__.)
+  get(signal, envir = .__HANDLERS__.)
+}
+
+signal_fire <- function(signal, ...) {
+  handlers <- signal_handlers_get(signal)
+  for (id in objects(handlers, all.names = TRUE)) {
+    handler <- get(id, envir = handlers)
+    try(handler(...), silent = TRUE)
+  }
+}
+
+signal_on <- function(signal, fn) {
+  handlers <- signal_handlers_get(signal)
+  id <- digest::digest(fn)
+  handlers[[id]] <- fn
+  id
+}
+
+signal_off <- function(signal, id) {
+  handlers <- signal_handlers_get(signal)
+  handlers[[id]] <- NULL
+}


### PR DESCRIPTION
This PR implements a simple signal / slot system, and uses it for signalling expectation results outside of `test_that` calls.