### PR TITLE
Explicit fmt argument with safe default to difference()

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -24,8 +24,8 @@ comparison <- function(equal = TRUE, message = "Equal") {
     class = "comparison"
   )
 }
-difference <- function(...) {
-  comparison(FALSE, sprintf(...))
+difference <- function(..., fmt = "%s") {
+  comparison(FALSE, sprintf(fmt, ...))
 }
 no_difference <- function() {
   comparison()
@@ -56,10 +56,10 @@ print_out <- function(x, ...) {
 # Common helpers ---------------------------------------------------------------
 
 same_length <- function(x, y) length(x) == length(y)
-diff_length <- function(x, y) difference("Lengths differ: %i vs %i", length(x), length(y))
+diff_length <- function(x, y) difference(fmt = "Lengths differ: %i vs %i", length(x), length(y))
 
 same_type <- function(x, y) identical(typeof(x), typeof(y))
-diff_type <- function(x, y) difference("Types not compatible: %s vs %s", typeof(x), typeof(y))
+diff_type <- function(x, y) difference(fmt = "Types not compatible: %s vs %s", typeof(x), typeof(y))
 
 same_class <- function(x, y) {
   if (!is.object(x) && !is.object(y))
@@ -67,7 +67,7 @@ same_class <- function(x, y) {
   identical(class(x), class(y))
 }
 diff_class <- function(x, y) {
-  difference("Classes differ: %s vs %s", klass(x), klass(y))
+  difference(fmt = "Classes differ: %s vs %s", klass(x), klass(y))
 }
 
 same_attr <- function(x, y) {

--- a/tests/testthat/test-expect-equality.R
+++ b/tests/testthat/test-expect-equality.R
@@ -29,3 +29,9 @@ test_that("useful message if objects equal but not identical", {
   expect_failure(expect_identical(f, g), "not identical")
 })
 
+
+test_that("% is not treated as sprintf format specifier (#445)", {
+  expect_failure(expect_equal("+", "%"))
+  expect_failure(expect_equal("%", "+"))
+  expect_equal("%", "%")
+})


### PR DESCRIPTION
Fixes #445.

**NEWS entry**:

```
- Hardened formatting of difference messages, previously the presence of % characters could affect the output (#446, @krlmlr).
```