### PR TITLE
comparison() accepts messages of length > 1

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -14,12 +14,12 @@ compare <- function(x, y, ...) {
 
 comparison <- function(equal = TRUE, message = "Equal") {
   stopifnot(is.logical(equal), length(equal) == 1)
-  stopifnot(is.character(message), length(message) == 1)
+  stopifnot(is.character(message))
 
   structure(
     list(
       equal = equal,
-      message = message
+      message = paste(message, collapse = "\n")
     ),
     class = "comparison"
   )

--- a/R/compare.R
+++ b/R/compare.R
@@ -24,8 +24,8 @@ comparison <- function(equal = TRUE, message = "Equal") {
     class = "comparison"
   )
 }
-difference <- function(...) {
-  comparison(FALSE, sprintf(...))
+difference <- function(..., fmt = "%s") {
+  comparison(FALSE, sprintf(fmt, ...))
 }
 no_difference <- function() {
   comparison()
@@ -56,10 +56,10 @@ print_out <- function(x, ...) {
 # Common helpers ---------------------------------------------------------------
 
 same_length <- function(x, y) length(x) == length(y)
-diff_length <- function(x, y) difference("Lengths differ: %i vs %i", length(x), length(y))
+diff_length <- function(x, y) difference(fmt = "Lengths differ: %i vs %i", length(x), length(y))
 
 same_type <- function(x, y) identical(typeof(x), typeof(y))
-diff_type <- function(x, y) difference("Types not compatible: %s vs %s", typeof(x), typeof(y))
+diff_type <- function(x, y) difference(fmt = "Types not compatible: %s vs %s", typeof(x), typeof(y))
 
 same_class <- function(x, y) {
   if (!is.object(x) && !is.object(y))
@@ -67,7 +67,7 @@ same_class <- function(x, y) {
   identical(class(x), class(y))
 }
 diff_class <- function(x, y) {
-  difference("Classes differ: %s vs %s", klass(x), klass(y))
+  difference(fmt = "Classes differ: %s vs %s", klass(x), klass(y))
 }
 
 same_attr <- function(x, y) {

--- a/tests/testthat/test-expect-equality.R
+++ b/tests/testthat/test-expect-equality.R
@@ -29,3 +29,9 @@ test_that("useful message if objects equal but not identical", {
   expect_failure(expect_identical(f, g), "not identical")
 })
 
+
+test_that("% is not treated as sprintf format specifier (#445)", {
+  expect_failure(expect_equal("+", "%"))
+  expect_failure(expect_equal("%", "+"))
+  expect_equal("%", "%")
+})

--- a/tests/testthat/test-expect-equality.R
+++ b/tests/testthat/test-expect-equality.R
@@ -29,9 +29,15 @@ test_that("useful message if objects equal but not identical", {
   expect_failure(expect_identical(f, g), "not identical")
 })
 
-
 test_that("% is not treated as sprintf format specifier (#445)", {
   expect_failure(expect_equal("+", "%"))
   expect_failure(expect_equal("%", "+"))
   expect_equal("%", "%")
+})
+
+test_that("attributes for object (#452)", {
+  oops <- structure(0, oops = "oops")
+  expect_equal(oops, oops)
+  expect_failure(expect_equal(oops, 0))
+  expect_equal(as.numeric(oops), 0)
 })


### PR DESCRIPTION
Fixes #452.

Closes #446 (=includes it. because of conflict).

**NEWS entries**:

```
- Hardened formatting of difference messages, previously the presence of % characters could affect the output (#446, @krlmlr).
- Fixed errors in `expect_equal()` when comparing numeric vectors with and without attributes (#453, @krlmlr).
```
