### PR TITLE
don't use partial argument matching

### DIFF
--- a/R/traceback.R
+++ b/R/traceback.R
@@ -3,7 +3,7 @@ create_traceback <- function(callstack) {
   max_lines <- getOption("deparse.max.lines", Inf)
 
   # Convert to text
-  calls <- lapply(callstack, deparse, width = getOption("width"))
+  calls <- lapply(callstack, deparse, width.cutoff = getOption("width"))
   if (is.finite(max_lines)) {
     calls <- lapply(calls, function(x) x[seq_len(min(length(x), max_lines))])
   }

--- a/tests/testthat/test-compare-numeric.R
+++ b/tests/testthat/test-compare-numeric.R
@@ -48,7 +48,7 @@ test_that("unnamed arguments to all.equal passed through correctly", {
 })
 
 test_that("named arguments to all.equal passed through", {
-  expect_equal(415, 416, tol = 0.01)
+  expect_equal(415, 416, tolerance = 0.01)
 })
 
 test_that("tolerance used for individual comparisons", {
@@ -56,7 +56,7 @@ test_that("tolerance used for individual comparisons", {
   x2 <- x1 + c(0, 0, 0.1)
 
   expect_false(compare(x1, x2)$equal)
-  expect_true(compare(x1, x2, tol = 0.1)$equal)
+  expect_true(compare(x1, x2, tolerance = 0.1)$equal)
 })
 
 


### PR DESCRIPTION
updated version of #443, with three updates to use full rather than partial argument matching.