### PR TITLE
Use deep cloning of reporters in auto_test() and auto_test_package()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     methods
 Suggests:
     devtools,
+    withr,
     covr
 License: MIT + file LICENSE
 Collate:

--- a/R/auto-test.R
+++ b/R/auto-test.R
@@ -38,7 +38,7 @@ auto_test <- function(code_path, test_path, reporter = "summary",
 
   # Start by loading all code and running all tests
   source_dir(code_path, env = env)
-  test_dir(test_path, env = env, reporter = reporter$clone())
+  test_dir(test_path, env = env, reporter = reporter$clone(deep = TRUE))
 
   # Next set up watcher to monitor changes
   watcher <- function(added, deleted, modified) {
@@ -52,11 +52,11 @@ auto_test <- function(code_path, test_path, reporter = "summary",
       cat("Changed code: ", paste0(basename(code), collapse = ", "), "\n")
       cat("Rerunning all tests\n")
       source_dir(code_path, env = env)
-      test_dir(test_path, env = env, reporter = reporter$clone())
+      test_dir(test_path, env = env, reporter = reporter$clone(deep = TRUE))
     } else if (length(tests) > 0) {
       # If test changes, rerun just that test
       cat("Rerunning tests: ", paste0(basename(tests), collapse = ", "), "\n")
-      test_files(tests, env = env, reporter = reporter$clone())
+      test_files(tests, env = env, reporter = reporter$clone(deep = TRUE))
     }
 
     TRUE
@@ -88,7 +88,7 @@ auto_test_package <- function(pkg = ".", reporter = "summary") {
   env <- devtools::load_all(pkg)$env
   devtools::with_envvar(
     devtools::r_env_vars(),
-    test_dir(test_path, env = env, reporter = reporter$clone())
+    test_dir(test_path, env = env, reporter = reporter$clone(deep = TRUE))
   )
 
   # Next set up watcher to monitor changes
@@ -105,14 +105,14 @@ auto_test_package <- function(pkg = ".", reporter = "summary") {
       env <<- devtools::load_all(pkg, quiet = TRUE)$env
       devtools::with_envvar(
         devtools::r_env_vars(),
-        test_dir(test_path, env = env, reporter = reporter$clone())
+        test_dir(test_path, env = env, reporter = reporter$clone(deep = TRUE))
       )
     } else if (length(tests) > 0) {
       # If test changes, rerun just that test
       cat("Rerunning tests: ", paste0(basename(tests), collapse = ", "), "\n")
       devtools::with_envvar(
         devtools::r_env_vars(),
-        test_files(tests, env = env, reporter = reporter$clone())
+        test_files(tests, env = env, reporter = reporter$clone(deep = TRUE))
       )
     }
 

--- a/R/auto-test.R
+++ b/R/auto-test.R
@@ -86,7 +86,7 @@ auto_test_package <- function(pkg = ".", reporter = "summary") {
 
   # Start by loading all code and running all tests
   env <- devtools::load_all(pkg)$env
-  devtools::with_envvar(
+  withr::with_envvar(
     devtools::r_env_vars(),
     test_dir(test_path, env = env, reporter = reporter$clone(deep = TRUE))
   )
@@ -103,14 +103,14 @@ auto_test_package <- function(pkg = ".", reporter = "summary") {
       cat("Changed code: ", paste0(basename(code), collapse = ", "), "\n")
       cat("Rerunning all tests\n")
       env <<- devtools::load_all(pkg, quiet = TRUE)$env
-      devtools::with_envvar(
+      withr::with_envvar(
         devtools::r_env_vars(),
         test_dir(test_path, env = env, reporter = reporter$clone(deep = TRUE))
       )
     } else if (length(tests) > 0) {
       # If test changes, rerun just that test
       cat("Rerunning tests: ", paste0(basename(tests), collapse = ", "), "\n")
-      devtools::with_envvar(
+      withr::with_envvar(
         devtools::r_env_vars(),
         test_files(tests, env = env, reporter = reporter$clone(deep = TRUE))
       )

--- a/R/stack.R
+++ b/R/stack.R
@@ -20,26 +20,26 @@ Stack <- R6Class(
 
     push = function(..., .list = NULL) {
       args <- c(list(...), .list)
-      new_size <- count + length(args)
+      new_size <- private$count + length(args)
 
       # Grow if needed; double in size
-      while (new_size > length(stack)) {
-        stack[length(stack) * 2L] <<- list(NULL)
+      while (new_size > length(private$stack)) {
+        private$stack[length(private$stack) * 2L] <- list(NULL)
       }
-      stack[count + seq_along(args)] <<- args
-      count <<- new_size
+      private$stack[private$count + seq_along(args)] <- args
+      private$count <- new_size
 
       invisible(self)
     },
 
     size = function() {
-      count
+      private$count
     },
 
     # Return the entire stack as a list, where the first item in the list is the
     # oldest item in the stack, and the last item is the most recently added.
     as_list = function() {
-      stack[seq_len(count)]
+      private$stack[seq_len(private$count)]
     }
   ),
 

--- a/R/stack.R
+++ b/R/stack.R
@@ -6,7 +6,7 @@
 # the stack changes in size.
 Stack <- R6Class(
   'Stack',
-  portable = FALSE,
+  portable = TRUE,
   class = FALSE,
   public = list(
 


### PR DESCRIPTION
Fixes #441. CC @nealrichardson.

Also uses withr::with_envvar() instead of devtools::with_envvar() to avoid warning.

Testing auto_test() and auto_test_package() is tricky, but not impossible. An external R script that runs for a certain time can be started using a pattern like this:

```
system("Rscript -e 'Sys.sleep(Inf)' & sleep 1")
```

The output of that script could be then analyzed by the test.

**NEWS entry**:

```
- `auto_test()` and `auto_test_package()` show only the results of the current test run and not of previously failed runs (#456, @krlmlr).
```