### PR TITLE
Extend TapReporter with option to write to file; fix tests in test-reporter-tap.R

### DIFF
--- a/R/reporter-tap.R
+++ b/R/reporter-tap.R
@@ -15,6 +15,11 @@ TapReporter <- R6::R6Class("TapReporter", inherit = Reporter,
     has_tests = FALSE,
     contexts = NA_character_,
 
+    initialize = function(file=stdout()) {
+      super$initialize()
+      self$out <- file
+    },
+    
     start_context = function(context) {
       self$contexts[self$n + 1] <- context
     },

--- a/inst/include/testthat/testthat.h
+++ b/inst/include/testthat/testthat.h
@@ -55,7 +55,7 @@ extern "C" void R_FlushConsole();
 
 namespace testthat {
 
-class r_streambuf : public std::basic_streambuf<char> {
+class r_streambuf : public std::streambuf {
 public:
 
   r_streambuf() {}
@@ -89,9 +89,9 @@ protected:
 
 };
 
-class r_ostream : public std::basic_ostream<char> {
+class r_ostream : public std::ostream {
 public:
-  r_ostream() : std::basic_ostream<char>(new r_streambuf) {}
+  r_ostream() : std::ostream(new r_streambuf) {}
   ~r_ostream() { delete rdbuf(); }
 };
 

--- a/inst/include/testthat/vendor/catch.h
+++ b/inst/include/testthat/vendor/catch.h
@@ -3203,7 +3203,6 @@ namespace Catch {
         }
 
         virtual ~Config() {
-            m_os.rdbuf( Catch::cout().rdbuf() );
             m_stream.release();
         }
 

--- a/tests/testthat/test-reporter-tap.R
+++ b/tests/testthat/test-reporter-tap.R
@@ -1,10 +1,17 @@
 context("TAP reporter")
 
+tap.report <- capture.output(test_dir("test_dir", reporter = "tap"))
+
 test_that("TAP reporter handles context and pass/fail/skip", {
-  tap.report <- capture.output(test_dir("test_dir", reporter = "tap"))
   expect_identical(tap.report[1], "1..24")
   expect_identical(tap.report[2], "# Context Bare ")
   expect_true("ok 7 equality holds " %in% tap.report)
   expect_true("not ok 10 empty test with error " %in% tap.report)
   expect_true("ok 24 # SKIP Skipping to avoid certain failure " %in% tap.report)
+})
+
+test_that("TAP reporter can write to file", {
+  tapfile <- tempfile()
+  test_dir("test_dir", reporter = TapReporter$new(file=tapfile))
+  expect_identical(readLines(tapfile), tap.report)
 })


### PR DESCRIPTION
I run tests for a package on Jenkins, and to communicate test results, it uses TAP. Jenkins processes test output after the tests are run and needs to read TAP output from a file, so I've been doing something like:

```
sink(file="filename.tap")
test_check("package", reporter="tap")
sink()
```

This works fine until some code that executes in the test suite prints output unexpectedly. Because the TapReporter doesn't (and in fact can't) `cat` out its results until all tests have completed, any other printing is captured by the sink first and is included at the top of the TAP file output. This leads Jenkins to fail on parsing the output because the first line is not the TAP header. 

To solve this problem, I wanted to have the TapReporter be able to control where it wrote its output. I modified the `initialize` method of the `TapReporter` class to take an optional "file" argument. If supplied, the TAP output is written out to that file. With this, I can eliminate the `sink` and run the tests on Jenkins as:

```
test_check("package", reporter=TapReporter$new(file="filename.tap"))
```

Only the TAP output goes to the file, and any additional printing continues to go to stdout, visible in the Jenkins job log and safely outside of the TAP file.

With this change, the default behavior of the TapReporter is unaffected, and the tests in test-reporter-tap.R confirm this as well as the new behavior.

Incidentally, while working on this feature, I noticed that the expectations in test-reporter-tap.R were not running. Something is odd about running `test_dir` inside of `test_that`. I'm opening a separate issue for that as I haven't had a chance to investigate/fix it yet. [This commit](https://github.com/hadley/testthat/commit/fa7a27b7b89900667a8126a8b00ce3523aa4e661) moves the `test_dir` call outside of the test_that block and then updates the test expectations so that they pass once again. 