### PR TITLE
New load_helpers arg to test_dir()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat 1.0.2.9000
 
+* New argument `load_helpers` in `test_dir()` (#505).
+
 * New `DebugReporter` that calls a better version of `recover()` in case of failures, errors, or warnings (#360, #470).
 
 * `compare.numeric()` respects `check.attributes()` so `expect_equivalent()`

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -18,18 +18,19 @@ test_env <- function() {
 #' \code{helper} and loaded before any tests are run.
 #'
 #' @param path path to tests
-#' @param reporter reporter to use
 #' @param filter If not \code{NULL}, only tests with file names matching this
 #'   regular expression will be executed.  Matching will take on the file
 #'   name after it has been stripped of \code{"test-"} and \code{".R"}.
-#' @param env environment in which to execute test suite.
 #' @param ... Additional arguments passed to \code{grepl} to control filtering.
+#' @inheritParams test_file
 #'
 #' @return the results as a "testthat_results" (list)
 #' @export
 test_dir <- function(path, filter = NULL, reporter = "summary",
-                                          env = test_env(), ...) {
-  source_test_helpers(path, env)
+                     env = test_env(), ..., load_helpers = TRUE) {
+  if (load_helpers) {
+    source_test_helpers(path, env)
+  }
   paths <- find_test_scripts(path, filter, ...)
 
   test_files(paths, reporter = reporter, env = env, ...)

--- a/man/test_dir.Rd
+++ b/man/test_dir.Rd
@@ -4,7 +4,8 @@
 \alias{test_dir}
 \title{Run all of the tests in a directory.}
 \usage{
-test_dir(path, filter = NULL, reporter = "summary", env = test_env(), ...)
+test_dir(path, filter = NULL, reporter = "summary", env = test_env(), ...,
+  load_helpers = TRUE)
 }
 \arguments{
 \item{path}{path to tests}
@@ -15,9 +16,11 @@ name after it has been stripped of \code{"test-"} and \code{".R"}.}
 
 \item{reporter}{reporter to use}
 
-\item{env}{environment in which to execute test suite.}
+\item{env}{environment in which to execute the tests}
 
 \item{...}{Additional arguments passed to \code{grepl} to control filtering.}
+
+\item{load_helpers}{Source helper files before running the tests?}
 }
 \value{
 the results as a "testthat_results" (list)


### PR DESCRIPTION
So that devtools doesn't need to load the helpers twice when running the tests.