### PR TITLE
Add encoding support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # testthat 1.0.2.9000
 
+* New argument`encoding` in `test_file()` and `source_file()` (@hansharhoff, hadley/devtools#1306)
+
 * New argument `load_helpers` in `test_dir()` (#505).
 
 * New `DebugReporter` that calls a better version of `recover()` in case of failures, errors, or warnings (#360, #470).

--- a/R/source.R
+++ b/R/source.R
@@ -8,6 +8,7 @@
 #' @param pattern Regular expression used to filter files
 #' @param env Environment in which to evaluate code.
 #' @param chdir Change working directory to \code{dirname(path)}?
+#' @param encoding File encoding, default: "unknown"
 #' @export
 source_file <- function(path, env = test_env(), chdir = TRUE, encoding = "unknown") {
   stopifnot(file.exists(path))

--- a/R/source.R
+++ b/R/source.R
@@ -9,11 +9,11 @@
 #' @param env Environment in which to evaluate code.
 #' @param chdir Change working directory to \code{dirname(path)}?
 #' @export
-source_file <- function(path, env = test_env(), chdir = TRUE) {
+source_file <- function(path, env = test_env(), chdir = TRUE, encoding = "unknown") {
   stopifnot(file.exists(path))
   stopifnot(is.environment(env))
 
-  lines <- readLines(path, warn = FALSE)
+  lines <- readLines(path, warn = FALSE, encoding = encoding)
   srcfile <- srcfilecopy(path, lines, file.info(path)[1, "mtime"], isFile = TRUE)
   exprs <- parse(text = lines, n = -1, srcfile = srcfile)
 

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -27,16 +27,16 @@ test_env <- function() {
 #' @return the results as a "testthat_results" (list)
 #' @export
 test_dir <- function(path, filter = NULL, reporter = "summary",
-                     env = test_env(), ..., load_helpers = TRUE) {
+                     env = test_env(), ..., encoding = "unknown", load_helpers = TRUE) {
   if (load_helpers) {
     source_test_helpers(path, env)
   }
   paths <- find_test_scripts(path, filter, ...)
 
-  test_files(paths, reporter = reporter, env = env, ...)
+  test_files(paths, reporter = reporter, env = env, encoding = encoding, ...)
 }
 
-test_files <- function(paths, reporter = "summary",
+test_files <- function(paths, reporter = "summary", encoding = "unknown",
                        env = test_env(), ...) {
   if (length(paths) == 0) {
     stop('No matching test file in dir')
@@ -51,7 +51,8 @@ test_files <- function(paths, reporter = "summary",
       env = env,
       reporter = current_reporter,
       start_end_reporter = FALSE,
-      load_helpers = FALSE
+      load_helpers = FALSE,
+      encoding = encoding
     )
   )
 
@@ -98,6 +99,8 @@ find_test_scripts <- function(path, filter = NULL, invert = FALSE, ...) {
 #' @param reporter reporter to use
 #' @param env environment in which to execute the tests
 #' @param load_helpers Source helper files before running the tests?
+#' @param encoding the encoding of the files in test directory. Default is
+#' \code{unknown}.
 #' @inheritParams with_reporter
 #' @return the results as a "testthat_results" (list)
 #' @export

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -33,11 +33,11 @@ test_dir <- function(path, filter = NULL, reporter = "summary",
   }
   paths <- find_test_scripts(path, filter, ...)
 
-  test_files(paths, reporter = reporter, env = env, encoding = encoding, ...)
+  test_files(paths, reporter = reporter, env = env, encoding = encoding)
 }
 
-test_files <- function(paths, reporter = "summary", encoding = "unknown",
-                       env = test_env(), ...) {
+test_files <- function(paths, reporter = "summary", env = test_env(),
+                       encoding = "unknown") {
   if (length(paths) == 0) {
     stop('No matching test file in dir')
   }
@@ -99,7 +99,7 @@ find_test_scripts <- function(path, filter = NULL, invert = FALSE, ...) {
 #' @param reporter reporter to use
 #' @param env environment in which to execute the tests
 #' @param load_helpers Source helper files before running the tests?
-#' @param encoding the encoding of the files in test directory. Default is
+#' @param encoding File encoding, default is "unknown"
 #' \code{unknown}.
 #' @inheritParams with_reporter
 #' @return the results as a "testthat_results" (list)

--- a/R/test-files.R
+++ b/R/test-files.R
@@ -102,7 +102,8 @@ find_test_scripts <- function(path, filter = NULL, invert = FALSE, ...) {
 #' @return the results as a "testthat_results" (list)
 #' @export
 test_file <- function(path, reporter = "summary", env = test_env(),
-                      start_end_reporter = TRUE, load_helpers = TRUE) {
+                      start_end_reporter = TRUE, load_helpers = TRUE,
+                      encoding = "unknown") {
   library(testthat)
 
   reporter <- find_reporter(reporter)
@@ -124,7 +125,8 @@ test_file <- function(path, reporter = "summary", env = test_env(),
     {
       lister$start_file(basename(path))
 
-      source_file(path, new.env(parent = env), chdir = TRUE)
+      source_file(path, new.env(parent = env),
+                  chdir = TRUE, encoding = encoding)
       end_context()
     }
   )

--- a/man/source_file.Rd
+++ b/man/source_file.Rd
@@ -6,7 +6,7 @@
 \alias{source_test_helpers}
 \title{Source a file, directory, or all helpers.}
 \usage{
-source_file(path, env = test_env(), chdir = TRUE)
+source_file(path, env = test_env(), chdir = TRUE, encoding = "unknown")
 
 source_dir(path, pattern = "\\\\.[rR]$", env = test_env(), chdir = TRUE)
 
@@ -18,6 +18,8 @@ source_test_helpers(path = "tests/testthat", env = test_env())
 \item{env}{Environment in which to evaluate code.}
 
 \item{chdir}{Change working directory to \code{dirname(path)}?}
+
+\item{encoding}{File encoding, default: "unknown"}
 
 \item{pattern}{Regular expression used to filter files}
 }

--- a/man/test_dir.Rd
+++ b/man/test_dir.Rd
@@ -5,7 +5,7 @@
 \title{Run all of the tests in a directory.}
 \usage{
 test_dir(path, filter = NULL, reporter = "summary", env = test_env(), ...,
-  load_helpers = TRUE)
+  encoding = "unknown", load_helpers = TRUE)
 }
 \arguments{
 \item{path}{path to tests}
@@ -19,6 +19,9 @@ name after it has been stripped of \code{"test-"} and \code{".R"}.}
 \item{env}{environment in which to execute the tests}
 
 \item{...}{Additional arguments passed to \code{grepl} to control filtering.}
+
+\item{encoding}{the encoding of the files in test directory. Default is
+\code{unknown}.}
 
 \item{load_helpers}{Source helper files before running the tests?}
 }

--- a/man/test_dir.Rd
+++ b/man/test_dir.Rd
@@ -20,7 +20,7 @@ name after it has been stripped of \code{"test-"} and \code{".R"}.}
 
 \item{...}{Additional arguments passed to \code{grepl} to control filtering.}
 
-\item{encoding}{the encoding of the files in test directory. Default is
+\item{encoding}{File encoding, default is "unknown"
 \code{unknown}.}
 
 \item{load_helpers}{Source helper files before running the tests?}

--- a/man/test_file.Rd
+++ b/man/test_file.Rd
@@ -18,7 +18,7 @@ test_file(path, reporter = "summary", env = test_env(),
 
 \item{load_helpers}{Source helper files before running the tests?}
 
-\item{encoding}{the encoding of the files in test directory. Default is
+\item{encoding}{File encoding, default is "unknown"
 \code{unknown}.}
 }
 \value{

--- a/man/test_file.Rd
+++ b/man/test_file.Rd
@@ -5,7 +5,7 @@
 \title{Run all tests in specified file.}
 \usage{
 test_file(path, reporter = "summary", env = test_env(),
-  start_end_reporter = TRUE, load_helpers = TRUE)
+  start_end_reporter = TRUE, load_helpers = TRUE, encoding = "unknown")
 }
 \arguments{
 \item{path}{path to file}
@@ -17,6 +17,9 @@ test_file(path, reporter = "summary", env = test_env(),
 \item{start_end_reporter}{whether to start and end the reporter}
 
 \item{load_helpers}{Source helper files before running the tests?}
+
+\item{encoding}{the encoding of the files in test directory. Default is
+\code{unknown}.}
 }
 \value{
 the results as a "testthat_results" (list)


### PR DESCRIPTION
This pull request adds support for an encoding argument to test_dir (and the functions called by this). This is related to an [issue reported in devtools](https://github.com/hadley/devtools/issues/1306). A separate pull request is incoming for devtools.
