### PR TITLE
Escape regular expression characters in error output.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # testthat 1.0.2.9000
 
+* Special regular expression characters are escaped when printing errors in
+  `expect_match()` (#522, @jimhester).
+
 * New argument `load_helpers` in `test_dir()` (#505).
 
 * New `DebugReporter` that calls a better version of `recover()` in case of failures, errors, or warnings (#360, #470).

--- a/R/expectations-matches.R
+++ b/R/expectations-matches.R
@@ -31,16 +31,16 @@ expect_match <- function(object, regexp, ..., all = TRUE,
   matches <- grepl(regexp, object, ...)
 
   if (length(object) == 1) {
-    values <- paste0("Actual value: \"", encodeString(object), "\"")
+    values <- paste0("Actual value: \"", escape_regex(encodeString(object)), "\"")
   } else {
     values <- paste0("Actual values:\n",
-      paste0("* ", encodeString(object), collapse = "\n"))
+      paste0("* ", escape_regex(encodeString(object)), collapse = "\n"))
   }
   expect(
     if (all) all(matches) else any(matches),
     sprintf(
       "%s does not match %s.\n%s",
-      label,
+      escape_regex(label),
       encodeString(regexp, quote = '"'),
       values
     ),

--- a/R/utils.R
+++ b/R/utils.R
@@ -92,3 +92,8 @@ f_name <- function(x) {
     ""
   }
 }
+
+escape_regex <- function(x) {
+  chars <- c("*", ".", "?", "^", "+", "$", "|", "(", ")", "[", "]", "{", "}", "\\")
+  gsub(paste0("([\\", paste0(collapse = "\\", chars), "])"), "\\\\\\1", x, perl = TRUE)
+}

--- a/tests/testthat/test-expect-match.R
+++ b/tests/testthat/test-expect-match.R
@@ -9,3 +9,8 @@ test_that("extra arguments to matches passed onto grepl", {
 
 })
 
+test_that("special regex characters are escaped in output", {
+  error <- tryCatch(expect_match("f() test", "f() test"), expectation = function(e) e$message)
+  expect_equal(error, "\"f\\(\\) test\" does not match \"f() test\".\nActual value: \"f\\(\\) test\"\n")
+})
+


### PR DESCRIPTION
This should make it more clear why something that looks identical did
not match.

e.g. expect_match("foo() is not bar", "foo() is not bar")
