### PR TITLE
Avoid using find_label

### DIFF
--- a/R/expect-comparison.R
+++ b/R/expect-comparison.R
@@ -22,12 +22,9 @@ NULL
 
 expect_compare <- function(operator = c("<", "<=", ">", ">="),
                            actual, expected,
-                           label = NULL, expected.label = NULL) {
+                           label, expected.label) {
   operator <- match.arg(operator)
   op <- match.fun(operator)
-
-  lab_act <- make_label(actual, label)
-  lab_exp <- make_label(expected, expected.label)
 
   stopifnot(is.numeric(actual), length(actual) == 1)
   stopifnot(is.numeric(expected), length(expected) == 1)
@@ -42,32 +39,40 @@ expect_compare <- function(operator = c("<", "<=", ">", ">="),
   diff <- actual - expected
   expect(
     op(diff, 0),
-    sprintf("%s is %s %s. Difference: %.3g", lab_act, msg, lab_exp, diff)
+    sprintf("%s is %s %s. Difference: %.3g", label, msg, expected.label, diff)
   )
   invisible(actual)
 }
 #' @export
 #' @rdname comparison-expectations
 expect_lt <- function(object, expected, label = NULL, expected.label = NULL) {
-  expect_compare("<", object, expected, label = label, expected.label = expected.label)
+  lab_act <- make_label(substitute(object), label)
+  lab_exp <- make_label(substitute(expected), expected.label)
+  expect_compare("<", object, expected, label = lab_act, expected.label = lab_exp)
 }
 
 #' @export
 #' @rdname comparison-expectations
 expect_lte <- function(object, expected, label = NULL, expected.label = NULL) {
-  expect_compare("<=", object, expected, label = label, expected.label = expected.label)
+  lab_act <- make_label(substitute(object), label)
+  lab_exp <- make_label(substitute(expected), expected.label)
+  expect_compare("<=", object, expected, label = lab_act, expected.label = lab_exp)
 }
 
 #' @export
 #' @rdname comparison-expectations
 expect_gt <- function(object, expected, label = NULL, expected.label = NULL) {
-  expect_compare(">", object, expected, label = label, expected.label = expected.label)
+  lab_act <- make_label(substitute(object), label)
+  lab_exp <- make_label(substitute(expected), expected.label)
+  expect_compare(">", object, expected, label = lab_act, expected.label = lab_exp)
 }
 
 #' @export
 #' @rdname comparison-expectations
 expect_gte <- function(object, expected, label = NULL, expected.label = NULL) {
-  expect_compare(">=", object, expected, label = label, expected.label = expected.label)
+  lab_act <- make_label(substitute(object), label)
+  lab_exp <- make_label(substitute(expected), expected.label)
+  expect_compare(">=", object, expected, label = lab_act, expected.label = lab_exp)
 }
 
 

--- a/R/expect-equal-to-reference.R
+++ b/R/expect-equal-to-reference.R
@@ -33,7 +33,7 @@
 expect_equal_to_reference <- function(object, file, ..., info = NULL,
                                       label = NULL, expected.label = NULL) {
 
-  lab_act <- make_label(object, label)
+  lab_act <- make_label(substitute(object), label)
   lab_exp <- expected.label %||% paste0("reference from `", file, "`")
 
   if (!file.exists(file)) {

--- a/R/expect-equality.R
+++ b/R/expect-equality.R
@@ -47,9 +47,8 @@ NULL
 #' @param ... other values passed to \code{\link{all.equal}}
 expect_equal <- function(object, expected, ..., info = NULL, label = NULL,
                          expected.label = NULL) {
-
-  lab_act <- make_label(object, label)
-  lab_exp <- make_label(expected, expected.label)
+  lab_act <- make_label(substitute(object), label)
+  lab_exp <- make_label(substitute(expected), expected.label)
 
   comp <- compare(object, expected, ...)
   expect(
@@ -65,8 +64,8 @@ expect_equal <- function(object, expected, ..., info = NULL, label = NULL,
 #' @rdname equality-expectations
 expect_equivalent <- function(object, expected, info = NULL, label = NULL,
                               expected.label = NULL) {
-  lab_act <- make_label(object, label)
-  lab_exp <- make_label(expected, expected.label)
+  lab_act <- make_label(substitute(object), label)
+  lab_exp <- make_label(substitute(expected), expected.label)
 
   comp <- compare(object, expected, check.attributes = FALSE)
   expect(
@@ -82,8 +81,8 @@ expect_equivalent <- function(object, expected, info = NULL, label = NULL,
 expect_identical <- function(object, expected, info = NULL, label = NULL,
                              expected.label = NULL) {
 
-  lab_act <- make_label(object, label)
-  lab_exp <- make_label(expected, expected.label)
+  lab_act <- make_label(substitute(object), label)
+  lab_exp <- make_label(substitute(expected), expected.label)
 
   ident <- identical(object, expected)
   if (ident) {

--- a/R/expect-inheritance.R
+++ b/R/expect-inheritance.R
@@ -32,7 +32,7 @@ NULL
 #' @export
 #' @rdname inheritance-expectations
 expect_null <- function(object, info = NULL, label = NULL) {
-  lab <- make_label(object, label)
+  lab <- make_label(substitute(object), label)
 
   expect(
     is.null(object),
@@ -47,7 +47,7 @@ expect_null <- function(object, info = NULL, label = NULL) {
 expect_type <- function(object, type) {
   stopifnot(is.character(type), length(type) == 1)
 
-  lab <- make_label(object)
+  lab <- make_label(substitute(object))
   act <- typeof(object)
   exp <- type
 
@@ -65,7 +65,7 @@ expect_type <- function(object, type) {
 expect_is <- function(object, class, info = NULL, label = NULL) {
   stopifnot(is.character(class))
 
-  lab <- make_label(object, label)
+  lab <- make_label(substitute(object), label)
   act <- klass(object)
   exp <- paste(class, collapse = "/")
 
@@ -82,7 +82,7 @@ expect_is <- function(object, class, info = NULL, label = NULL) {
 expect_s3_class <- function(object, class) {
   stopifnot(is.character(class))
 
-  lab <- label(object)
+  lab <- label(substitute(object))
   act <- klass(object)
   exp <- paste(class, collapse = "/")
 
@@ -102,7 +102,7 @@ expect_s3_class <- function(object, class) {
 expect_s4_class <- function(object, class) {
   stopifnot(is.character(class))
 
-  lab <- label(object)
+  lab <- label(substitute(object))
   act <- paste(methods::is(object), collapse = "/")
   exp <- paste(class, collapse = "/")
 

--- a/R/expect-length.R
+++ b/R/expect-length.R
@@ -13,7 +13,7 @@
 #' }
 expect_length <- function(object, n) {
   stopifnot(is.numeric(n), length(n) == 1)
-  lab <- label(object)
+  lab <- label(substitute(object))
 
   if (!is_vector(object)) {
     fail(sprintf("%s is not a vector.", lab))

--- a/R/expect-logical.R
+++ b/R/expect-logical.R
@@ -29,7 +29,7 @@ NULL
 #' @export
 #' @rdname logical-expectations
 expect_true <- function(object, info = NULL, label = NULL) {
-  lab <- make_label(object, label)
+  lab <- make_label(substitute(object), label)
 
   expect(
     identical(as.vector(object), TRUE),
@@ -42,7 +42,7 @@ expect_true <- function(object, info = NULL, label = NULL) {
 #' @export
 #' @rdname logical-expectations
 expect_false <- function(object, info = NULL, label = NULL) {
-  lab <- make_label(object, label)
+  lab <- make_label(substitute(object), label)
 
   expect(
     identical(as.vector(object), FALSE),

--- a/R/expect-named.R
+++ b/R/expect-named.R
@@ -29,7 +29,7 @@ expect_named <- function(object, expected, ignore.order = FALSE,
                          ignore.case = FALSE, info = NULL,
                          label = NULL) {
 
-  lab <- make_label(object, label)
+  lab <- make_label(substitute(object), label)
 
   if (missing(expected)) {
     expect(

--- a/R/expect-output.R
+++ b/R/expect-output.R
@@ -84,7 +84,7 @@ NULL
 #' @export
 #' @rdname output-expectations
 expect_output <- function(object, regexp = NULL, ..., info = NULL, label = NULL) {
-  lab <- make_label(object, label)
+  lab <- make_label(substitute(object), label)
   output <- capture_output(object)
 
   if (identical(regexp, NA)) {
@@ -112,7 +112,7 @@ expect_output <- function(object, regexp = NULL, ..., info = NULL, label = NULL)
 #' @param update Should the "golden" text file be updated? Default: \code{FALSE}.
 expect_output_file <- function(object, file, update = FALSE, ...,
                                info = NULL, label = NULL) {
-  lab <- make_label(object, label)
+  lab <- make_label(substitute(object), label)
   output <- capture_output_as_vector(object)
 
   withCallingHandlers(
@@ -131,7 +131,7 @@ expect_output_file <- function(object, file, update = FALSE, ...,
 #' @rdname output-expectations
 expect_error <- function(object, regexp = NULL, ..., info = NULL, label = NULL) {
 
-  lab <- make_label(object, label)
+  lab <- make_label(substitute(object), label)
 
   error <- tryCatch(
     {
@@ -166,7 +166,7 @@ expect_error <- function(object, regexp = NULL, ..., info = NULL, label = NULL) 
 expect_message <- function(object, regexp = NULL, ..., all = FALSE,
                            info = NULL, label = NULL) {
 
-  lab <- make_label(object, label)
+  lab <- make_label(substitute(object), label)
   messages <- capture_messages(object)
   n <- length(messages)
   bullets <- paste("* ", messages, collapse = "\n")
@@ -196,7 +196,7 @@ expect_message <- function(object, regexp = NULL, ..., all = FALSE,
 expect_warning <- function(object, regexp = NULL, ..., all = FALSE,
                            info = NULL, label = NULL) {
 
-  lab <- make_label(object, label)
+  lab <- make_label(substitute(object), label)
   warnings <- capture_warnings(object)
   n <- length(warnings)
   bullets <- paste("* ", warnings, collapse = "\n")
@@ -224,7 +224,7 @@ expect_warning <- function(object, regexp = NULL, ..., all = FALSE,
 #' @export
 #' @rdname output-expectations
 expect_silent <- function(object) {
-  lab <- label(object)
+  lab <- label(substitute(object))
   out <- evaluate_promise(object)
 
   outputs <- c(

--- a/R/expect-that.R
+++ b/R/expect-that.R
@@ -19,6 +19,7 @@
 #' expect_that(sqrt(2) ^ 2, is_identical_to(2))
 #' }
 expect_that <- function(object, condition, info = NULL, label = NULL) {
+  label <- make_label(substitute(object), label)
   condition(object)
 }
 

--- a/R/expectation.R
+++ b/R/expectation.R
@@ -53,8 +53,6 @@ add_info <- function(message, info = NULL) {
 }
 
 label <- function(x) {
-  x <- find_label(x)
-
   if (is.character(x)) {
     encodeString(x, quote = '"')
   } else if (is.atomic(x)) {
@@ -70,10 +68,14 @@ label <- function(x) {
   }
 }
 
-#' @useDynLib testthat find_label_
-find_label <- function(x) {
-  .Call(find_label_, quote(x), environment())
-}
+# This function should not be used as it depends on that all function
+# arguments are wrapped into promises; it is better not to depend on this
+# and now it does not hold with the byte-code compiler.
+#
+# #' @useDynLib testthat find_label_
+# find_label <- function(x) {
+#  .Call(find_label_, quote(x), environment())
+# }
 
 expectation_type <- function(exp) {
   stopifnot(is.expectation(exp))

--- a/R/expectations-matches.R
+++ b/R/expectations-matches.R
@@ -21,7 +21,7 @@
 expect_match <- function(object, regexp, ..., all = TRUE,
                          info = NULL, label = NULL) {
   stopifnot(is.character(regexp), length(regexp) == 1)
-  label <- make_label(object, label)
+  label <- make_label(substitute(object), label)
 
   stopifnot(is.character(object))
   if (length(object) == 0) {

--- a/tests/testthat/test-label.R
+++ b/tests/testthat/test-label.R
@@ -8,21 +8,21 @@ test_that("labelling compound {} expression gives single string", {
 })
 
 
-test_that("can find label after it's been forced", {
-  f <- function(x) {
-    force(x)
-    find_label(x)
-  }
-
-  abc <- 100
-
-  expect_equal(f(abc), quote(abc))
-})
-
-test_that("can find label even when deeply nested", {
-  f <- function(x) g(x)
-  g <- function(y) h(y)
-  h <- function(z) find_label(z)
-
-  expect_equal(f(abc), quote(abc))
-})
+#test_that("can find label after it's been forced", {
+#  f <- function(x) {
+#    force(x)
+#    find_label(x)
+#  }
+#
+#  abc <- 100
+#
+#  expect_equal(f(abc), quote(abc))
+#})
+#
+#test_that("can find label even when deeply nested", {
+#  f <- function(x) g(x)
+#  g <- function(y) h(y)
+#  h <- function(z) find_label(z)
+#
+#  expect_equal(f(abc), quote(abc))
+#})


### PR DESCRIPTION
This patch replaces the use of find_label in testthat by substitute. The problem of find_label is that it depends on that function arguments are always promised (e.g. even when they are constants, always re-promised, etc). This is an internal behavior of R that is not safe to depend on, this behavior can change (mostly for performance reasons), and it already changed in the byte-code compiler where constants are not wrapped into promises. So this patch is needed for testthat to work with the byte-code compiler. It may be worth removing find_label from the code completely (I already commented it out for now). There is also some maintenance advantage of this patch in avoiding native code.
