### PR TITLE
clarify `skip` semantics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -100,6 +100,8 @@
 
 * New JUnit reporter `JunitReporter`. (#481, @lbartnik)
 
+* Clarified `skip` semantics in documentation (@brodieG)
+
 # testthat 1.0.2
 
 * Ensure `std::logic_error()` constructed with `std::string()`

--- a/R/skip.R
+++ b/R/skip.R
@@ -41,7 +41,7 @@
 #' ## run with `test_file`, `test_dir`, `test_check`, etc.
 #'
 #' test_that("skip example", {
-#'   expect_equal(1, 1L)     # this expectation runs
+#'   expect_equal(1, 1L)    # this expectation runs
 #'   skip('skip')
 #'   expect_equal(1, 2)     # this one skipped
 #'   expect_equal(1, 3)     # this one is also skipped

--- a/R/skip.R
+++ b/R/skip.R
@@ -4,11 +4,11 @@
 #' This will produce an informative message, but will not cause the test
 #' suite to fail.
 #'
-#' \code{skip*} functions are intended for use within \code{\link{test_that}}
+#' `skip*` functions are intended for use within [test_that()]
 #' blocks.  All expectations following the \code{skip*} statement within the
-#' same \code{test_that} block will be skipped.  Note that test summaries
-#' that report skip counts are reporting how many \code{test_that} blocks
-#' triggered a \code{skip*} statement, not how many expectations were skipped.
+#' same `test_that` block will be skipped.  Test summaries that report skip
+#' counts are reporting how many `test_that` blocks triggered a `skip*`
+#' statement, not how many expectations were skipped.
 #'
 #' @section Helpers:
 #' `skip_if_not()` works like [stopifnot()], generating
@@ -27,17 +27,15 @@
 #' `BBS_HOME` environment variable.
 #'
 #' `skip_if_not_installed()` skips a tests if a package is not installed
-#' or cannot be loaded
-#' (useful for suggested packages).
-#' It loads the package as a side effect, because the package is likely to be
-#' used anyway.
+#' or cannot be loaded (useful for suggested packages).  It loads the package as
+#' a side effect, because the package is likely to be used anyway.
 #'
 #' @param message A message describing why the test was skipped.
 #' @export
 #' @examples
 #' if (FALSE) skip("No internet connection")
 #'
-#' ## The following are only meaningful when put in test files and 
+#' ## The following are only meaningful when put in test files and
 #' ## run with `test_file`, `test_dir`, `test_check`, etc.
 #'
 #' test_that("skip example", {

--- a/R/skip.R
+++ b/R/skip.R
@@ -4,6 +4,12 @@
 #' This will produce an informative message, but will not cause the test
 #' suite to fail.
 #'
+#' \code{skip*} functions are intended for use within \code{\link{test_that}}
+#' blocks.  All expectations following the \code{skip*} statement within the
+#' same \code{test_that} block will be skipped.  Note that test summaries
+#' that report skip counts are reporting how many \code{test_that} blocks
+#' triggered a \code{skip*} statement, not how many expectations were skipped.
+#'
 #' @section Helpers:
 #' `skip_if_not()` works like [stopifnot()], generating
 #' a message automatically based on the first argument.
@@ -30,6 +36,16 @@
 #' @export
 #' @examples
 #' if (FALSE) skip("No internet connection")
+#'
+#' ## The following are only meaningful when put in test files and 
+#' ## run with `test_file`, `test_dir`, `test_check`, etc.
+#'
+#' test_that("skip example", {
+#'   expect_equal(1, 1L)     # this expectation runs
+#'   skip('skip')
+#'   expect_equal(1, 2)     # this one skipped
+#'   expect_equal(1, 3)     # this one is also skipped
+#' })
 skip <- function(message) {
   cond <- structure(list(message = message), class = c("skip", "condition"))
   stop(cond)

--- a/man/skip.Rd
+++ b/man/skip.Rd
@@ -45,6 +45,13 @@ This function allows you to skip a test if it's not currently available.
 This will produce an informative message, but will not cause the test
 suite to fail.
 }
+\details{
+\code{skip*} functions are intended for use within \code{\link{test_that}}
+blocks.  All expectations following the \code{skip*} statement within the
+same \code{test_that} block will be skipped.  Note that test summaries
+that report skip counts are reporting how many \code{test_that} blocks
+triggered a \code{skip*} statement, not how many expectations were skipped.
+}
 \section{Helpers}{
 
 \code{skip_if_not()} works like \code{\link[=stopifnot]{stopifnot()}}, generating
@@ -71,4 +78,14 @@ used anyway.
 
 \examples{
 if (FALSE) skip("No internet connection")
+
+## The following are only meaningful when put in test files and 
+## run with `test_file`, `test_dir`, `test_check`, etc.
+
+test_that("skip example", {
+  expect_equal(1, 1L)     # this expectation runs
+  skip('skip')
+  expect_equal(1, 2)     # this one skipped
+  expect_equal(1, 3)     # this one is also skipped
+})
 }

--- a/man/skip.Rd
+++ b/man/skip.Rd
@@ -46,7 +46,7 @@ This will produce an informative message, but will not cause the test
 suite to fail.
 }
 \details{
-\code{skip*} functions are intended for use within \code{\link{test_that}}
+\code{skip*} functions are intended for use within \code{\link[=test_that]{test_that()}}
 blocks.  All expectations following the \code{skip*} statement within the
 same \code{test_that} block will be skipped.  Note that test summaries
 that report skip counts are reporting how many \code{test_that} blocks
@@ -70,20 +70,18 @@ environment variable set by devtools.
 \code{BBS_HOME} environment variable.
 
 \code{skip_if_not_installed()} skips a tests if a package is not installed
-or cannot be loaded
-(useful for suggested packages).
-It loads the package as a side effect, because the package is likely to be
-used anyway.
+or cannot be loaded (useful for suggested packages).  It loads the package as
+a side effect, because the package is likely to be used anyway.
 }
 
 \examples{
 if (FALSE) skip("No internet connection")
 
-## The following are only meaningful when put in test files and 
+## The following are only meaningful when put in test files and
 ## run with `test_file`, `test_dir`, `test_check`, etc.
 
 test_that("skip example", {
-  expect_equal(1, 1L)     # this expectation runs
+  expect_equal(1, 1L)    # this expectation runs
   skip('skip')
   expect_equal(1, 2)     # this one skipped
   expect_equal(1, 3)     # this one is also skipped


### PR DESCRIPTION
I couldn't quite tell precisely what `skip` did from documentation alone.  My initial incorrect impression was that it would skip the subsequent test only.  I think it is worth clarifying in the documentation what happens exactly in case others interpret it as I did.