### PR TITLE
Make broken expectations catchable by try()

### DIFF
--- a/R/expectation.R
+++ b/R/expectation.R
@@ -22,6 +22,8 @@ expectation <- function(type, message, srcref = NULL) {
     class = c(
       paste0("expectation_", type),
       "expectation",
+      # Make broken expectations catchable by try()
+      if (type %in% c("failure", "error")) "error",
       "condition"
     )
   )


### PR DESCRIPTION
Currently, broken expectations break rmarkdown document rendering
even if knitr chunk option error=TRUE. It also breaks the evaluate
package's ability to capture errors.

This PR is just a starting point for discussion, if you like it I can add
tests.