### PR TITLE
Write TAP report to a file specified via options()

### DIFF
--- a/R/reporter-tap.R
+++ b/R/reporter-tap.R
@@ -30,6 +30,13 @@ TapReporter <- R6::R6Class("TapReporter", inherit = Reporter,
       if (!self$has_tests)
         return()
 
+      # Check to see if an output_file path has been specified
+      self$out <- getOption("testthat.tap.output_file", self$out)
+      if (is.character(self$out) && file.exists(self$out)) {
+        # If writing to a file, overwrite it if it exists
+        file.remove(self$out)
+      }
+
       self$cat_line("1..", self$n)
       for (i in 1:self$n) {
         if (!is.na(self$contexts[i])) {

--- a/R/reporter.R
+++ b/R/reporter.R
@@ -34,7 +34,8 @@ Reporter <- R6::R6Class("Reporter",
         warning("append ignored", call. = FALSE)
       }
 
-      cat(..., file = self$out, sep = sep, fill = fill, labels = labels)
+      cat(..., file = self$out, sep = sep, fill = fill, labels = labels,
+        append = is.character(self$out)) # If writing to file, append=TRUE
     },
 
     cat_tight = function(...) {

--- a/tests/testthat/test-reporter.R
+++ b/tests/testthat/test-reporter.R
@@ -87,20 +87,19 @@ tap_expected <- test_path("reporters", "tap.txt")
 tap_output <- tempfile()
 withr::with_options(list(testthat.tap.output_file=tap_output), {
   test_that("TAP output_file is used if specified", {
-    test_reporter(find_reporter("tap"))
+    expect_silent(test_reporter(find_reporter("tap")))
     expect_identical(readLines(tap_output), readLines(tap_expected))
   })
   test_that("TAP output_file is overwritten if it already exists", {
-    test_reporter(find_reporter("tap"))
+    expect_silent(test_reporter(find_reporter("tap")))
     expect_identical(readLines(tap_output), readLines(tap_expected))
   })
 })
 
-tap_expected <- test_path("reporters", "tap.txt")
 junit_output <- tempfile()
 withr::with_options(list(testthat.junit.output_file=junit_output), {
   test_that("junit output_file is used if specified", {
-    test_reporter(createJunitReporterMock())
+    expect_silent(test_reporter(createJunitReporterMock()))
     expect_identical(readLines(junit_output),
       readLines(test_path("reporters", "junit.txt")))
   })

--- a/tests/testthat/test-reporter.R
+++ b/tests/testthat/test-reporter.R
@@ -38,6 +38,14 @@ test_that("character vector yields multi reporter", {
   )
 })
 
+test_reporter <- function(reporter) {
+  # Function to run the reporter "test suite" with a given reporter
+  withr::with_options(
+    list(expressions = Cstack_info()[["eval_depth"]] + 200),
+    test_file(test_path("reporters/tests.R"), reporter, wrap = FALSE)
+  )
+}
+
 test_that("reporters produce consistent output", {
   old <- options(width = 80)
   on.exit(options(old), add = TRUE)
@@ -47,10 +55,7 @@ test_that("reporters produce consistent output", {
 
     expect_output_file(
       expect_error(
-        withr::with_options(
-          list(expressions = Cstack_info()[["eval_depth"]] + 200),
-          test_file(test_path("reporters/tests.R"), reporter, wrap = FALSE)
-        ),
+        test_reporter(reporter),
         error_regexp
       ),
       path, update = TRUE)
@@ -76,4 +81,27 @@ test_that("reporters produce consistent output", {
   save_report("silent")
   save_report("rstudio")
   save_report("junit", reporter = createJunitReporterMock())
+})
+
+tap_expected <- test_path("reporters", "tap.txt")
+tap_output <- tempfile()
+withr::with_options(list(testthat.tap.output_file=tap_output), {
+  test_that("TAP output_file is used if specified", {
+    test_reporter(find_reporter("tap"))
+    expect_identical(readLines(tap_output), readLines(tap_expected))
+  })
+  test_that("TAP output_file is overwritten if it already exists", {
+    test_reporter(find_reporter("tap"))
+    expect_identical(readLines(tap_output), readLines(tap_expected))
+  })
+})
+
+tap_expected <- test_path("reporters", "tap.txt")
+junit_output <- tempfile()
+withr::with_options(list(testthat.junit.output_file=junit_output), {
+  test_that("junit output_file is used if specified", {
+    test_reporter(createJunitReporterMock())
+    expect_identical(readLines(junit_output),
+      readLines(test_path("reporters", "junit.txt")))
+  })
 })


### PR DESCRIPTION
https://github.com/hadley/testthat/pull/467 proposed a way for the TAP reporter to write its output to a file, but its approach was seen as inconsistent with the other reporters, and it was closed. Since then, a JUnit reporter has been added to `testthat` (https://github.com/hadley/testthat/pull/481), and it allows specifying a "testthat.junit.output_file" option to direct the reporter to write to a file rather than stdout (https://github.com/hadley/testthat/pull/576). 

This pull request brings the TAP reporter in line with the JUnit one by adding a "testthat.tap.output_file" option, which, if set, similarly writes the TAP output to the specified file. The PR also adds a test for the JUnit reporter when "testthat.junit.output_file" is set.