### PR TITLE
expect_cpp_tests_pass looks for run_testthat_tests in testthat package

### DIFF
--- a/R/test-compiled-code.R
+++ b/R/test-compiled-code.R
@@ -14,7 +14,7 @@
 #' @export
 expect_cpp_tests_pass <- function(package) {
 
-  run_testthat_tests <- get_routine(package, "run_testthat_tests")
+  run_testthat_tests <- get_routine("testthat", "run_testthat_tests")
 
   output <- ""
   tests_passed <- TRUE


### PR DESCRIPTION
run_testthat_tests has been registered in testthat package, so get_routine has to look for it there.  