### PR TITLE
testthat/catch/Rcpp compatibility workaround

### DIFF
--- a/R/test-compiled-code.R
+++ b/R/test-compiled-code.R
@@ -196,8 +196,15 @@ get_routine <- function(package, routine) {
     error = function(e) NULL
   )
 
-  if (is.null(resolved))
-    stop("failed to locate routine '", routine, "' in package '", package, "'", call. = FALSE)
+  if (is.null(resolved)){
+    # Has Rcpp altered the routine's name?
+    resolved <- tryCatch(
+      getNativeSymbolInfo(paste0("_", package, "_", routine), PACKAGE = package),
+      error = function(e) NULL
+    )
+    if (is.null(resolved))
+      stop("failed to locate routine '", routine, "' in package '", package, "'", call. = FALSE)
+  }
 
   resolved
 }

--- a/inst/resources/test-runner.cpp
+++ b/inst/resources/test-runner.cpp
@@ -5,3 +5,6 @@
  */
 #define TESTTHAT_TEST_RUNNER
 #include <testthat.h>
+
+// [[Rcpp::export]]
+extern "C" SEXP run_testthat_tests();


### PR DESCRIPTION
If used, Rcpp disables dynamic loading of native routines and  'monopolizes' the registration of native routines in the package. This workaround intstructs Rcpp (if present)  to register 'run_testthat_tests' routine needed to run Catch tests and forces get_routine() to look for Rcpp-altered version of run_testthat_tests instead of failing if it can't find plain 'run_testthat_tests'. It is not very elegant, but testhat/catch now works with or without Rcpp and remains independent of Rcpp.